### PR TITLE
Call Fox Improvements and Memory Editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 
-AtlusScriptCompiler\.log
+AtlusScriptCompiler*\.log
 build/input/extracted/**
 *.bin
 build_local.bat
 build/output/**
 build/input/**
 *.lnk
+.vscode

--- a/ModMenu/CallMenu.flow
+++ b/ModMenu/CallMenu.flow
@@ -416,7 +416,7 @@ int Battles2()
 
 int BGMSelect()
 {
-	int bgm = Get_Number(9, MSG_5);
+	int bgm = Get_Number(5, MSG_5);
 	if (bgm == -1)
 		return -1;
 	CALL_BGM(bgm);

--- a/ModMenu/FlagMenu.flow
+++ b/ModMenu/FlagMenu.flow
@@ -14,18 +14,24 @@ int Flag_Menu()
 				ToggleBitRange();
 				break;
 			case 2:
-				KillQuests();
+				EditCount();
 				break;
 			case 3:
-				ReviveQuests();
+				EditMemory();
 				break;
 			case 4:
-				TurnOffTiredFlags();
+				KillQuests();
 				break;
 			case 5:
-				UnlockMap();
+				ReviveQuests();
 				break;
 			case 6:
+				TurnOffTiredFlags();
+				break;
+			case 7:
+				UnlockMap();
+				break;
+			case 8:
 				ToggleHUD();
 				break;
 			case 17:
@@ -66,6 +72,39 @@ void UnlockMap()
 	BIT_ON( 0 + 0x0400 + 0x0800 + 0x0400 + 0x0200 + 0x0200 + 0x0200 + 85 );
 	BIT_OFF( 0 + 0x0400 + 0x0800 + 177 );
 	BIT_ON( 0 + 0x0400 + 0x0800 + 175 );
+}
+
+void EditCount()
+{
+	int countNumber = Get_Number(3, MSG_3);
+	if (countNumber == -1)
+		return;
+	SET_MSG_VAR(0, countNumber, 0);
+	SET_MSG_VAR(1, GET_CNT(countNumber), 0);
+	OPEN_MSG_WIN();
+	MSG(CountIndicator);
+	CLOSE_MSG_WIN();
+	int newValue = Get_Number(5, MSG_5);
+	if (newValue != -1)
+		SET_CNT(countNumber, newValue);
+}
+
+void EditMemory() 
+{
+	// Get the location
+	int op = ADV_SEL(Operation, PlusOrMinus, 0);
+	int location = Get_Number(6, MSG_6_Location);
+	if(location == -1)
+		return;
+	if (op) location *= -1;
+	// Get the number of bytes
+	int numBytes = Get_Number(2, MSG_2_Bytes);
+	int foundNumber = ReadNumber(location, numBytes);
+	SET_MSG_VAR(0, location, 0);
+	SET_MSG_VAR(1, foundNumber, 0);
+	OPEN_MSG_WIN();
+	MSG(NumberIndicator);
+	CLOSE_MSG_WIN();
 }
 
 void ToggleBit()

--- a/ModMenu/FlagMenu.flow
+++ b/ModMenu/FlagMenu.flow
@@ -1,43 +1,50 @@
 int Flag_Menu()
 {
-	while(true)
+	int page = 0;
+	while (true)
 	{
+		SEL_CHK_PAD(10, 20);
+		SEL_CHK_PAD(11, 20);
+		SEL_CHK_PAD(5, 20);
+		SEL_CHK_PAD(7, 20);
 		SEL_CHK_PAD(14, 17);
 		SEL_CHK_PAD(15, 18);
-		int flag = ADV_SEL(Flag_Menu_Text, Flag_Menu, 0);
-		switch (flag) 
+		int flag = ADV_SEL(Flag_Menu_Text + page, Flag_Menu + page, 0);
+		switch (flag)
 		{
-			case 0:
+		case 0:
+			if(page == 0)
 				ToggleBit();
-				break;
-			case 1:
-				ToggleBitRange();
-				break;
-			case 2:
-				EditCount();
-				break;
-			case 3:
-				EditMemory();
-				break;
-			case 4:
-				KillQuests();
-				break;
-			case 5:
+			else 
 				ReviveQuests();
-				break;
-			case 6:
+			break;
+		case 1:
+			if(page == 0)
+				ToggleBitRange();
+			else	
 				TurnOffTiredFlags();
-				break;
-			case 7:
+			break;
+		case 2:
+			if(page == 0)
+				EditCount();
+			else
 				UnlockMap();
-				break;
-			case 8:
+			break;
+		case 3:
+			if(page == 0)
+				EditMemory();
+			else
 				ToggleHUD();
-				break;
-			case 17:
-				return -1;
-			case 18:
-				return 0;
+			break;
+		case 4:
+			KillQuests();
+			break;
+		case 17:
+			return -1;
+		case 18:
+			return 0;
+		case 20:
+			page = !page;
 		}
 	}
 	return 0;
@@ -45,7 +52,7 @@ int Flag_Menu()
 
 void ToggleHUD()
 {
-	SEL_CHK_PAD(14,2);
+	SEL_CHK_PAD(14, 2);
 	int toggle = ADV_SEL(OnOff_Text, OnOff, 0);
 	if (toggle == 0)
 		SHOW_DATE(1);
@@ -55,23 +62,23 @@ void ToggleHUD()
 
 void TurnOffTiredFlags()
 {
-	BIT_OFF( 0 + 0x0400 + 0x0800 + 2 );
-	BIT_OFF( 2750 );
+	BIT_OFF(0 + 0x0400 + 0x0800 + 2);
+	BIT_OFF(2750);
 }
 
 void UnlockMap()
 {
-	BIT_ON( 0 + 0x0400 + 0x0800 + 173 );
-	BIT_OFF( 0 + 0x0400 + 0x0800 + 176 );
-	BIT_ON( 0 + 0x0400 + 0x0800 + 174 );
-	SET_CNT( 62, 3 );
-	BIT_OFF( 0 + 0x0400 + 0x0800 + 181 );
-	BIT_ON( 0 + 0x0400 + 0x0800 + 180 );
-	SET_CNT( 63, 3 );
-	BIT_ON( 0 + 0x0400 + 0x0800 + 179 );
-	BIT_ON( 0 + 0x0400 + 0x0800 + 0x0400 + 0x0200 + 0x0200 + 0x0200 + 85 );
-	BIT_OFF( 0 + 0x0400 + 0x0800 + 177 );
-	BIT_ON( 0 + 0x0400 + 0x0800 + 175 );
+	BIT_ON(0 + 0x0400 + 0x0800 + 173);
+	BIT_OFF(0 + 0x0400 + 0x0800 + 176);
+	BIT_ON(0 + 0x0400 + 0x0800 + 174);
+	SET_CNT(62, 3);
+	BIT_OFF(0 + 0x0400 + 0x0800 + 181);
+	BIT_ON(0 + 0x0400 + 0x0800 + 180);
+	SET_CNT(63, 3);
+	BIT_ON(0 + 0x0400 + 0x0800 + 179);
+	BIT_ON(0 + 0x0400 + 0x0800 + 0x0400 + 0x0200 + 0x0200 + 0x0200 + 85);
+	BIT_OFF(0 + 0x0400 + 0x0800 + 177);
+	BIT_ON(0 + 0x0400 + 0x0800 + 175);
 }
 
 void EditCount()
@@ -89,22 +96,24 @@ void EditCount()
 		SET_CNT(countNumber, newValue);
 }
 
-void EditMemory() 
+void EditMemory()
 {
 	// Get the location
-	int op = ADV_SEL(Operation, PlusOrMinus, 0);
-	int location = Get_Number(6, MSG_6_Location);
-	if(location == -1)
+	int location = Get_Number(9, MSG_9_Location);
+	if (location == -1)
 		return;
-	if (op) location *= -1;
 	// Get the number of bytes
-	int numBytes = Get_Number(2, MSG_2_Bytes);
+	int numBytes = Get_Number(1, MSG_1_Bytes);
 	int foundNumber = ReadNumber(location, numBytes);
 	SET_MSG_VAR(0, location, 0);
 	SET_MSG_VAR(1, foundNumber, 0);
 	OPEN_MSG_WIN();
 	MSG(NumberIndicator);
 	CLOSE_MSG_WIN();
+	int newValue = Get_Number(6, MSG_6);
+	if (newValue == -1)
+		return;
+	WriteNumber(location, numBytes, newValue);
 }
 
 void ToggleBit()
@@ -116,7 +125,7 @@ void ToggleBit()
 	SET_MSG_VAR(1, 619 + BIT_CHK(major), 6);
 	OPEN_MSG_WIN();
 	MSG(FlagIndicator);
-	SEL_CHK_PAD(14,2);
+	SEL_CHK_PAD(14, 2);
 	int toggle = SEL(OnOff);
 	CLOSE_MSG_WIN();
 	if (toggle == 0)
@@ -138,7 +147,7 @@ void ToggleBitRange()
 	if (minor == -1)
 		return;
 	int i = major;
-	SEL_CHK_PAD(14,2);
+	SEL_CHK_PAD(14, 2);
 	int toggle = ADV_SEL(OnOff_Text, OnOff, 0);
 	if (toggle == 0)
 	{
@@ -161,14 +170,14 @@ void ToggleBitRange()
 void KillQuests()
 {
 	int var149 = 0 + 0x0100;
-	_1208:
-	
-	if ( 1 )
+_1208:
+
+	if (1)
 	{
-		BIT_ON( var149 );
+		BIT_ON(var149);
 		var149 = var149 + 1;
-		
-		if ( var149 > 0 + 447 )
+
+		if (var149 > 0 + 447)
 		{
 			goto _1209;
 		}
@@ -176,16 +185,16 @@ void KillQuests()
 		goto _1208;
 	}
 
-	_1209:
+_1209:
 	var149 = 0 + 0x0400 + 0x0800 + 0x0400 + 0x0200 + 0x0200 + 0x0200 + 768;
-	_1212:
-	
-	if ( 1 )
+_1212:
+
+	if (1)
 	{
-		BIT_ON( var149 );
+		BIT_ON(var149);
 		var149 = var149 + 1;
-		
-		if ( var149 > 0 + 0x0400 + 0x0800 + 0x0400 + 0x0200 + 0x0200 + 0x0200 + 863 )
+
+		if (var149 > 0 + 0x0400 + 0x0800 + 0x0400 + 0x0200 + 0x0200 + 0x0200 + 863)
 		{
 			goto _1213;
 		}
@@ -193,35 +202,35 @@ void KillQuests()
 		goto _1212;
 	}
 
-	_1213:
-	BIT_OFF( 0 + 306 );
-	BIT_OFF( 0 + 307 );
-	BIT_OFF( 0 + 308 );
-	BIT_OFF( 0 + 309 );
-	BIT_OFF( 0 + 310 );
-	BIT_OFF( 0 + 370 );
-	BIT_OFF( 0 + 371 );
-	BIT_OFF( 0 + 372 );
-	BIT_OFF( 0 + 373 );
-	BIT_OFF( 0 + 374 );
-	BIT_OFF( 0 + 434 );
-	BIT_OFF( 0 + 435 );
-	BIT_OFF( 0 + 436 );
-	BIT_OFF( 0 + 437 );
-	BIT_OFF( 0 + 438 );
+_1213:
+	BIT_OFF(0 + 306);
+	BIT_OFF(0 + 307);
+	BIT_OFF(0 + 308);
+	BIT_OFF(0 + 309);
+	BIT_OFF(0 + 310);
+	BIT_OFF(0 + 370);
+	BIT_OFF(0 + 371);
+	BIT_OFF(0 + 372);
+	BIT_OFF(0 + 373);
+	BIT_OFF(0 + 374);
+	BIT_OFF(0 + 434);
+	BIT_OFF(0 + 435);
+	BIT_OFF(0 + 436);
+	BIT_OFF(0 + 437);
+	BIT_OFF(0 + 438);
 }
 
 void ReviveQuests()
 {
 	int var149 = 0 + 0x0100;
-	_1216:
-	
-	if ( 1 )
+_1216:
+
+	if (1)
 	{
-		BIT_OFF( var149 );
+		BIT_OFF(var149);
 		var149 = var149 + 1;
-		
-		if ( var149 > 0 + 447 )
+
+		if (var149 > 0 + 447)
 		{
 			goto _1217;
 		}
@@ -229,16 +238,16 @@ void ReviveQuests()
 		goto _1216;
 	}
 
-	_1217:
+_1217:
 	var149 = 0 + 0x0400 + 0x0800 + 0x0400 + 0x0200 + 0x0200 + 0x0200 + 768;
-	_1220:
-	
-	if ( 1 )
+_1220:
+
+	if (1)
 	{
-		BIT_OFF( var149 );
+		BIT_OFF(var149);
 		var149 = var149 + 1;
-		
-		if ( var149 > 0 + 0x0400 + 0x0800 + 0x0400 + 0x0200 + 0x0200 + 0x0200 + 863 )
+
+		if (var149 > 0 + 0x0400 + 0x0800 + 0x0400 + 0x0200 + 0x0200 + 0x0200 + 863)
 		{
 			goto _1221;
 		}
@@ -246,5 +255,5 @@ void ReviveQuests()
 		goto _1220;
 	}
 
-	_1221:
+_1221:
 }

--- a/ModMenu/ModMenu.msg
+++ b/ModMenu/ModMenu.msg
@@ -87,6 +87,8 @@
 [sel Flag_Menu]
 [f 0 5 -258][f 2 1]Edit Flag[e]
 [f 0 5 -258][f 2 1]Mass Flag Edit[e]
+[f 0 5 -258][f 2 1]Edit Count[e]
+[f 0 5 -258][f 2 1]Edit Memory[e]
 [f 0 5 -258][f 2 1]Complete All Quests[e]
 [f 0 5 -258][f 2 1]Renew All Quests[e]
 [f 0 5 -258][f 2 1]Turn Off Tired Flags[e]
@@ -239,3 +241,9 @@
 
 [msg FlagIndicator]
 [f 0 5 -258][f 2 1]Flag [f 2 4 0] is set to [f 2 4 1].[n][e]
+
+[msg CountIndicator]
+[f 0 5 -258][f 2 1]Count [f 2 4 0] is set to [f 2 4 1].[n][f 1 1][e]
+
+[msg NumberIndicator]
+[f 0 5 -258][f 2 1]Location [f 2 4 0] is set to [f 2 4 1].[n][f 1 1][e]

--- a/ModMenu/ModMenu.msg
+++ b/ModMenu/ModMenu.msg
@@ -82,7 +82,10 @@
 [f 0 5 -258][f 2 1]Produce Shop[e]
 
 [msg Flag_Menu_Text]
-[f 0 5 -258][f 2 1]Flag Menu[n][f 1 1][e]
+[f 0 5 -258][f 2 1]Flag Menu (Page 1/2)[n][f 1 1][e]
+
+[msg Flag_Menu_Text_2]
+[f 0 5 -258][f 2 1]Flag Menu (Page 2/2)[n][f 1 1][e]
 
 [sel Flag_Menu]
 [f 0 5 -258][f 2 1]Edit Flag[e]
@@ -90,6 +93,8 @@
 [f 0 5 -258][f 2 1]Edit Count[e]
 [f 0 5 -258][f 2 1]Edit Memory[e]
 [f 0 5 -258][f 2 1]Complete All Quests[e]
+
+[sel Flag_Menu_2]
 [f 0 5 -258][f 2 1]Renew All Quests[e]
 [f 0 5 -258][f 2 1]Turn Off Tired Flags[e]
 [f 0 5 -258][f 2 1]Unlock Entire Town Map[e]

--- a/ModMenu/Utilities.flow
+++ b/ModMenu/Utilities.flow
@@ -1,74 +1,109 @@
-import( "Utilities.msg" );
+import("Utilities.msg");
 
 void Message_Window(int messageNum)
 {
-    OPEN_MSG_WIN();
-    MSG( messageNum );
-    CLOSE_MSG_WIN();
+	OPEN_MSG_WIN();
+	MSG(messageNum);
+	CLOSE_MSG_WIN();
 }
 
-int SelectDigit( int helpText )
+int SelectDigit(int helpText)
 {
-    while ( true )
-    {
+	while (true)
+	{
 		SEL_CHK_PAD(10, 10);
 		SEL_CHK_PAD(11, 10);
 		SEL_CHK_PAD(5, 10);
 		SEL_CHK_PAD(7, 10);
 		SEL_CHK_PAD(14, 11);
 		SEL_CHK_PAD(15, 12);
-		int digit = ADV_SEL( helpText, Num_Menu, 0);
-		if ( digit < 5 ) //0 through 4
+		int digit = ADV_SEL(helpText, Num_Menu, 0);
+		if (digit < 5) //0 through 4
 			return digit;
-		if ( digit == 10 )
-        {
+		if (digit == 10)
+		{
 			SEL_CHK_PAD(10, 10);
 			SEL_CHK_PAD(11, 10);
 			SEL_CHK_PAD(5, 10);
 			SEL_CHK_PAD(7, 10);
 			SEL_CHK_PAD(14, 11);
 			SEL_CHK_PAD(15, 12);
-            digit = ADV_SEL( helpText, Num_Menu2, 0) + 5;
-            if ( digit < 10 )
+			digit = ADV_SEL(helpText, Num_Menu2, 0) + 5;
+			if (digit < 10)
 				return digit; //5 through 9 or back
 			else if (digit == 16)
-			{	
+			{
 				digit = -1; //exit
 				break;
 			}
-        }
+		}
 		else if (digit == 11)
 		{
 			digit = -1; //exit
 			break;
 		}
-    }
+	}
 	return -1;
 }
 
-int Get_Number( int digitCount, int helpText )
+int Get_Number(int digitCount, int helpText)
 {
-	tryagain:
-    int number = 0;
-    
-    for ( int i = 0; i < digitCount; i++ )
-    {
-        int digit = SelectDigit(helpText);
+tryagain:
+	int number = 0;
+
+	for (int i = 0; i < digitCount; i++)
+	{
+		int digit = SelectDigit(helpText);
 		if (digit == -1)
 			return -1;
 		number *= 10;
 		number += digit;
-    }
-	
+	}
+
 	SET_MSG_VAR(0, number, 0);
 	OPEN_MSG_WIN();
-	MSG( ConfirmNumber );
+	MSG(ConfirmNumber);
 	SEL_CHK_PAD(14, 1);
 	int confirm = SEL(YESNO_SEL);
 	CLOSE_MSG_WIN();
 	if (confirm == 1)
 		goto tryagain;
 
-    return number;
+	return number;
 }
 
+/* 
+   Reads a number from "any" location in memory using bit checks
+   Numbers are read from a certain number of bits away from the first flag location
+   (LocationInMemory - 04DDD55C) * 8 gives you the number you want to input 
+   (LocationInMemory - 81646940) * 8 in decimal
+   Note: This number may be negative or positive depending on location, that is fine
+*/
+int ReadNumber(int baseLocation, int numBytes)
+{
+	int number = 0;
+	for (int i = 0; i < numBytes*8; i++)
+	{
+		// Get the next bit (little endian)
+		int bitLocation = baseLocation + i; 
+		bool foundBit = BIT_CHK(bitLocation);
+		// Convert the bit to a number, there's no power operator :(
+		int bitNumber = 0;
+		if(foundBit) {
+			bitNumber = 1;
+			for(int j = 0; j < i; j++) {
+				bitNumber *= 2;
+			}
+		}
+		number += bitNumber;
+		OPEN_MSG_WIN();
+		SET_MSG_VAR(0, i, 0);
+		SET_MSG_VAR(1, bitLocation, 0);
+		SET_MSG_VAR(2, foundBit, 0);
+		SET_MSG_VAR(3, bitNumber, 0);
+		SET_MSG_VAR(4, number, 0);
+		MSG(BIT_TEST);
+		CLOSE_MSG_WIN();
+	}
+	return number;
+}

--- a/ModMenu/Utilities.flow
+++ b/ModMenu/Utilities.flow
@@ -71,3 +71,4 @@ int Get_Number( int digitCount, int helpText )
 
     return number;
 }
+

--- a/ModMenu/Utilities.flow
+++ b/ModMenu/Utilities.flow
@@ -74,36 +74,56 @@ tryagain:
 
 /* 
    Reads a number from "any" location in memory using bit checks
-   Numbers are read from a certain number of bits away from the first flag location
-   (LocationInMemory - 04DDD55C) * 8 gives you the number you want to input 
-   (LocationInMemory - 81646940) * 8 in decimal
-   Note: This number may be negative or positive depending on location, that is fine
+   The baseLocation is the location in memory in integer form
 */
 int ReadNumber(int baseLocation, int numBytes)
 {
 	int number = 0;
-	for (int i = 0; i < numBytes*8; i++)
+	baseLocation -= 81646940; // Convert absolute memory location to distance from flags start
+	baseLocation *= 8;		  // Convert from bytes away from flag start to bits away
+	for (int i = 0; i < numBytes * 8; i++)
 	{
-		// Get the next bit (little endian)
-		int bitLocation = baseLocation + i; 
+		// Get the next bit
+		int bitLocation = baseLocation + i;
 		bool foundBit = BIT_CHK(bitLocation);
 		// Convert the bit to a number, there's no power operator :(
 		int bitNumber = 0;
-		if(foundBit) {
-			bitNumber = 1;
-			for(int j = 0; j < i; j++) {
-				bitNumber *= 2;
-			}
+		if (foundBit)
+		{
+			bitNumber = Power(2, i);
 		}
 		number += bitNumber;
-		OPEN_MSG_WIN();
-		SET_MSG_VAR(0, i, 0);
-		SET_MSG_VAR(1, bitLocation, 0);
-		SET_MSG_VAR(2, foundBit, 0);
-		SET_MSG_VAR(3, bitNumber, 0);
-		SET_MSG_VAR(4, number, 0);
-		MSG(BIT_TEST);
-		CLOSE_MSG_WIN();
 	}
 	return number;
+}
+
+void WriteNumber(int baseLocation, int numBytes, int number)
+{
+	baseLocation -= 81646940; // Convert absolute memory location to distance from flags start
+	baseLocation *= 8;		  // Convert from bytes away from flag start to bits away
+	int numBits = numBytes * 8 - 1;
+	for (int i = numBits; i >= 0; i--)
+	{
+		int bitLocation = baseLocation + i;
+		int power = Power(2, i);
+		if (number - power >= 0)
+		{
+			BIT_ON(bitLocation);
+			number -= power;
+		}
+		else
+		{
+			BIT_OFF(bitLocation);
+		}
+	}
+}
+
+int Power(int number, int power)
+{
+	int result = 1;
+	for (int j = 0; j < power; j++)
+	{
+		result *= number;
+	}
+	return result;
 }

--- a/ModMenu/Utilities.msg
+++ b/ModMenu/Utilities.msg
@@ -26,6 +26,9 @@
 [msg MSG_2]
 [f 0 5 -258][f 2 1]2 Digits[n][f 1 1][e]
 
+[msg MSG_2_Bytes]
+[f 0 5 -258][f 2 1]2 Digits (Number of Bytes)[n][f 1 1][e]
+
 [msg MSG_2_Day]
 [f 0 5 -258][f 2 1]2 Digits (Day)[n][f 1 1][e]
 
@@ -77,6 +80,9 @@
 [msg MSG_5_Minor]
 [f 0 5 -258][f 2 1]5 Digits (Minor)[n][f 1 1][e]
 
+[msg MSG_6_Location]
+[f 0 5 -258][f 2 1]6 Digits (Location)[n][f 1 1][e]
+
 [msg MSG_7]
 [f 0 5 -258][f 2 1]7 Digits (Yen)[n][f 1 1][e]
 
@@ -89,3 +95,8 @@
 
 [msg ConfirmItem]
 [f 0 5 -258][f 2 1]Selected item: [f 2 5 3 -1 0] × [f 2 4 1][e]
+
+[msg BIT_TEST]
+[f 0 5 -258][f 2 1]Bit [f 2 4 0] at location [f 2 4 1] is [f 2 4 2]
+[n]The bit number is [f 2 4 3]
+[n]The current total is [f 2 4 4][n][f 1 1][e]

--- a/ModMenu/Utilities.msg
+++ b/ModMenu/Utilities.msg
@@ -26,8 +26,8 @@
 [msg MSG_2]
 [f 0 5 -258][f 2 1]2 Digits[n][f 1 1][e]
 
-[msg MSG_2_Bytes]
-[f 0 5 -258][f 2 1]2 Digits (Number of Bytes)[n][f 1 1][e]
+[msg MSG_1_Bytes]
+[f 0 5 -258][f 2 1]1 Digit (Number of Bytes)[n][f 1 1][e]
 
 [msg MSG_2_Day]
 [f 0 5 -258][f 2 1]2 Digits (Day)[n][f 1 1][e]
@@ -80,8 +80,11 @@
 [msg MSG_5_Minor]
 [f 0 5 -258][f 2 1]5 Digits (Minor)[n][f 1 1][e]
 
-[msg MSG_6_Location]
-[f 0 5 -258][f 2 1]6 Digits (Location)[n][f 1 1][e]
+[msg MSG_9_Location]
+[f 0 5 -258][f 2 1]9 Digits (Location)[n][f 1 1][e]
+
+[msg MSG_6]
+[f 0 5 -258][f 2 1]6 Digits[n][f 1 1][e]
 
 [msg MSG_7]
 [f 0 5 -258][f 2 1]7 Digits (Yen)[n][f 1 1][e]
@@ -95,8 +98,3 @@
 
 [msg ConfirmItem]
 [f 0 5 -258][f 2 1]Selected item: [f 2 5 3 -1 0] × [f 2 4 1][e]
-
-[msg BIT_TEST]
-[f 0 5 -258][f 2 1]Bit [f 2 4 0] at location [f 2 4 1] is [f 2 4 2]
-[n]The bit number is [f 2 4 3]
-[n]The current total is [f 2 4 4][n][f 1 1][e]

--- a/OtherMods/ConsistentReaper.flow
+++ b/OtherMods/ConsistentReaper.flow
@@ -379,6 +379,7 @@ void dng_escape_hook()
         OPEN_MSG_WIN();
         MSG( ESCAPE_BAN );
         CLOSE_MSG_WIN();
+        return;
     }
     else 
 	{

--- a/OtherMods/ConsistentReaper.flow
+++ b/OtherMods/ConsistentReaper.flow
@@ -116,9 +116,16 @@ void death_check_hook()
         if ( var178 == 13 && BIT_CHK( 0 + 0x0400 + 0x0800 + 46 ) == 0 )
         {
 			// Set back to 0 so you'd need 21 more to trigger again
-			if (BIT_CHK(6328))
+			if (BIT_CHK(6328)) {
 				SET_CNT( 38, 14 );
+                // Display help message if it's the first encounter
+                if (!BIT_CHK(6335)) {
+                    HELP_MSG(HELP_REAPER);
+                    BIT_ON(6335);
+                }
+            }
             BIT_ON( 0 + 0x0400 + 0x0800 + 46 );
+
         }
 		else if (!BIT_CHK(6328))
 			BIT_OFF( 0 + 0x0400 + 0x0800 + 46 );

--- a/OtherMods/ConsistentReaper.msg
+++ b/OtherMods/ConsistentReaper.msg
@@ -1,2 +1,10 @@
 [msg New_Death_Msg]
 [f 0 5 -258][f 2 1]> You should hurry to the next floor...[n][f 1 1][e]
+
+[msg HELP_REAPER]
+[f 0 5 -258][f 2 1]When 21 chests have been opened, you[n]
+will begin to hear the sound of an[n]
+intensely terrifying presence...[n][f 1 1][e]
+[f 0 5 -258][f 2 1]Interacting with a chest and moving[n]
+on to another floor will cause the[n]
+chain rattling to cease.[n][f 1 1][e]

--- a/OtherMods/DungeonOptions/DungeonOptions.flow
+++ b/OtherMods/DungeonOptions/DungeonOptions.flow
@@ -108,7 +108,25 @@ void helper_order_hook()
     
     if ( 1 )
     {
+        // Set goho-m message variable
+        if (GET_FLOOR_ID() > 160 && GET_FLOOR_ID() < 180)
+        {
+            // Sacred branch (hollow forest)
+            SET_MSG_VAR(2, 885, 1);
+            SET_MSG_VAR(1, GET_ITEM(885), 0);
+        }
+        else if (GET_ITEM(790) != 0 || GET_ITEM(2099) == 0)
+        {
+            // Goho-m + Return Daikon
+            SET_MSG_VAR(2, 790, 1);
 		SET_MSG_VAR(1, GET_ITEM(790) + GET_ITEM(2099), 0);
+        }
+        else
+        {
+            // Return Daikon (if there are no goho-m)
+            SET_MSG_VAR(2, 2099, 1);
+            SET_MSG_VAR(1, GET_ITEM(2099), 0);
+        }
 		// Sets mask
         SET_MASK( sVar1 );
 		if (!BIT_CHK(6321))
@@ -453,7 +471,7 @@ void init_sel_mask_hook()
 	if (!EnableOrganizeParty() || !showOrganizeParty || !BIT_CHK(6324))
 		stratMask = stratMask + 16;
 	// Hide Call Fox
-	if ( BIT_CHK( 0 + 0x0400 + 0x0800 + 9 ) == 0 || !showFox || !BIT_CHK(6324))
+    if (BIT_CHK(0 + 0x0400 + 0x0800 + 9) == 0 || !showFox || !BIT_CHK(6324) || (GET_FLOOR_ID() > 160 && GET_FLOOR_ID() < 180))
 		sVar1 = sVar1 + 1024;
 	if ( !BIT_CHK(6326) || saveAnywhere() )
 		sVar1 = sVar1 + 2048;

--- a/OtherMods/DungeonOptions/DungeonOptions.flow
+++ b/OtherMods/DungeonOptions/DungeonOptions.flow
@@ -188,7 +188,7 @@ _100:
             goto _101;
         }
 
-        else if (var33 == 5)
+        else if (var33 == 6)
         {
             CLOSE_MSG_WIN();
             NAVI_BU_CLOSE(sVar7);
@@ -196,7 +196,7 @@ _100:
             goto_stair();
             return;
         }
-        else if (var33 == 6 || var33 == 7)
+        else if (var33 == 7 || var33 == 8)
         {
             CLOSE_MSG_WIN();
             NAVI_BU_CLOSE(sVar7);
@@ -205,12 +205,12 @@ _100:
             return;
         }
         // Select dungeon floor
-        else if (var33 == 8)
+        else if (var33 == 9)
         {
             SelectFloor();
             goto _101;
         }
-        else if (var33 == 9)
+        else if (var33 == 5)
         {
             use_gohom();
             goto _101;
@@ -439,11 +439,11 @@ _127:
     // Hide Go to next floor if floor select is shown
     if (FLD_FUNCTION_0036() == 0 || showFloorSelect == true)
     {
-        sVar1 = sVar1 + 32;
+        sVar1 = sVar1 + 64;
     }
 
     // Mask return to previous floor and entrance
-    sVar1 = sVar1 + 192;
+    sVar1 = sVar1 + 384;
 
     // Keep Return to previous floor/entrance hidden if floor select is shown
     if (FLD_FUNCTION_0037() == 1 && showFloorSelect == false)
@@ -451,23 +451,23 @@ _127:
         // Unmask entrance
         if (var34 == 6 || var34 == 21 || var34 == 41 || var34 == 61 || var34 == 81 || var34 == 101 || var34 == 121 || var34 == 123 || var34 == 141 || var34 == 161)
         {
-            sVar1 = sVar1 - 128;
+            sVar1 = sVar1 - 256;
         }
         // Unmask floor
         else
         {
-            sVar1 = sVar1 - 64;
+            sVar1 = sVar1 - 128;
         }
     }
 
     // Hide floor select
     if (!showFloorSelect || !BIT_CHK(6324))
-        sVar1 = sVar1 + 256;
+        sVar1 = sVar1 + 512;
     // Hide Goho-M
     if (!showGohom || showFloorSelect || !BIT_CHK(6324) ||
         (FLD_FUNCTION_0037() == 1 &&
          (var34 == 6 || var34 == 21 || var34 == 41 || var34 == 61 || var34 == 81 || var34 == 101 || var34 == 121 || var34 == 123 || var34 == 141 || var34 == 161)))
-        sVar1 = sVar1 + 512;
+        sVar1 = sVar1 + 32;
     // Hide OrganizeParty
     if (!EnableOrganizeParty() || !showOrganizeParty || !BIT_CHK(6324))
         stratMask = stratMask + 16;

--- a/OtherMods/DungeonOptions/DungeonOptions.flow
+++ b/OtherMods/DungeonOptions/DungeonOptions.flow
@@ -1,22 +1,21 @@
 
-// 
+//
 // FlowScript decompiled by AtlusScriptLib by TGE (2017)
 // In the unfortunate case of any bugs, please report them back to me.
-// 
+//
 
-
-// 
+//
 // Imports
-// 
+//
 
-import ("OrganizeParty.flow");
-import( "DungeonTravel.flow" );
-import( "GohoM.flow" );
-import( "Fox.flow" );
+import("OrganizeParty.flow");
+import("DungeonTravel.flow");
+import("GohoM.flow");
+import("Fox.flow");
 
-// 
+//
 // Script-level variable definitions
-// 
+//
 
 int stratMask;
 
@@ -24,52 +23,50 @@ int stratMask;
 void entrance_jump_hook()
 {
     int var29 = GET_FLOOR_ID();
-	int mask = 0;
-	if (!EnableOrganizeParty() || !BIT_CHK(6324))
-		mask = mask + 4;
-	if (!BeatDungeon() || !BIT_CHK(6324))
-		mask = mask + 2;
-	if (!BIT_CHK(6326) || saveAnywhere())
-		mask = mask + 8;
-    FUNCTION_0023( 0, 3 );
-    SEL_CHK_PAD( 14, 4 );
-	if (!BIT_CHK(6321))
-		SEL_CHK_PAD(12, 18);
-    int var27 = ADV_SEL( 15, ENTRANCE_SEL_HOOK, mask );
-    
-    if ( var27 == 0 )
+    int mask = 0;
+    if (!EnableOrganizeParty() || !BIT_CHK(6324))
+        mask = mask + 4;
+    if (!BeatDungeon() || !BIT_CHK(6324))
+        mask = mask + 2;
+    if (!BIT_CHK(6326) || saveAnywhere())
+        mask = mask + 8;
+    FUNCTION_0023(0, 3);
+    SEL_CHK_PAD(14, 4);
+    if (!BIT_CHK(6321))
+        SEL_CHK_PAD(12, 18);
+    int var27 = ADV_SEL(15, ENTRANCE_SEL_HOOK, mask);
+
+    if (var27 == 0)
     {
-        
-        if ( GET_MONTH() == 4 && GET_DAY_OF_MONTH() == 17 )
+
+        if (GET_MONTH() == 4 && GET_DAY_OF_MONTH() == 17)
         {
             OPEN_MSG_WIN();
-            MSG( STOP_RETURN_ENTRANCE );
+            MSG(STOP_RETURN_ENTRANCE);
             CLOSE_MSG_WIN();
         }
-        else 
+        else
         {
             return_tv_studio();
         }
-
     }
-    else if ( var27 == 1 )
+    else if (var27 == 1)
     {
-		SelectFloor();
+        SelectFloor();
     }
-	else if ( var27 == 2 )
+    else if (var27 == 2)
     {
-		OrganizeParty();
+        OrganizeParty();
     }
-	else if ( var27 == 3 )
-		NS_SAVE();
-	else if ( var27 == 18 )
-	{
-		MenuOptions();
-		options = true;
-	}
-	else
-		selected = false;
-
+    else if (var27 == 3)
+        NS_SAVE();
+    else if (var27 == 18)
+    {
+        MenuOptions();
+        options = true;
+    }
+    else
+        selected = false;
 }
 
 // Called mid dungeon
@@ -77,36 +74,34 @@ void helper_order_hook()
 {
     init_sel_mask();
     sVar9 = 30;
-    
-    if ( BIT_CHK( 0 + 52 ) == 1 )
+
+    if (BIT_CHK(0 + 52) == 1)
     {
         sVar8 = 5;
-        
-        if ( CHECK_TIME_SPAN( 6, 13, 10, 9 ) == 1 )
+
+        if (CHECK_TIME_SPAN(6, 13, 10, 9) == 1)
         {
             sVar9 = 20;
         }
-
     }
-    else 
+    else
     {
         sVar8 = 8;
     }
 
-    
-    if ( GET_FLOOR_ID() >= 160 && BIT_CHK( 0 + 0x0400 + 0x0800 + 136 ) == 1 )
+    if (GET_FLOOR_ID() >= 160 && BIT_CHK(0 + 0x0400 + 0x0800 + 136) == 1)
     {
-        BIT_OFF( 0 + 0x0400 + 0x0800 + 136 );
+        BIT_OFF(0 + 0x0400 + 0x0800 + 136);
     }
 
-    sVar7 = NAVI_BU_OPEN( 280, -40, sVar8, sVar9 );
+    sVar7 = NAVI_BU_OPEN(280, -40, sVar8, sVar9);
     OPEN_MSG_WIN();
     helper_dng_order();
 
-    _100:
+_100:
     int var33 = 0;
-    
-    if ( 1 )
+
+    if (1)
     {
         // Set goho-m message variable
         if (GET_FLOOR_ID() > 160 && GET_FLOOR_ID() < 180)
@@ -119,7 +114,7 @@ void helper_order_hook()
         {
             // Goho-m + Return Daikon
             SET_MSG_VAR(2, 790, 1);
-		SET_MSG_VAR(1, GET_ITEM(790) + GET_ITEM(2099), 0);
+            SET_MSG_VAR(1, GET_ITEM(790) + GET_ITEM(2099), 0);
         }
         else
         {
@@ -127,256 +122,250 @@ void helper_order_hook()
             SET_MSG_VAR(2, 2099, 1);
             SET_MSG_VAR(1, GET_ITEM(2099), 0);
         }
-		// Sets mask
-        SET_MASK( sVar1 );
-		if (!BIT_CHK(6321))
-			SEL_CHK_PAD(12, 18);
-        SEL_CHK_PAD( 14, 12 );
-        var33 = SEL( DUNGEON_SEL_HOOK );
-		
-		if ( var33 == 0 )
+        // Sets mask
+        SET_MASK(sVar1);
+        if (!BIT_CHK(6321))
+            SEL_CHK_PAD(12, 18);
+        SEL_CHK_PAD(14, 12);
+        var33 = SEL(DUNGEON_SEL_HOOK);
+
+        if (var33 == 0)
         {
             StrategizeMenu();
             goto _101;
         }
-        if ( var33 == 1 )
+        if (var33 == 1)
         {
             talk_member();
             goto _101;
         }
-        else if ( var33 == 2 || var33 == 3 )
+        else if (var33 == 2 || var33 == 3)
         {
-            
-            if ( var33 >= 2 && var33 <= 3 && GET_FLOOR_ID() < 160 )
+
+            if (var33 >= 2 && var33 <= 3 && GET_FLOOR_ID() < 160)
             {
-                
-                if ( GET_EQUIPMENT_ID( PartyUnit.Protagonist, 3 ) != GET_CNT( 242 ) && GET_EQUIPMENT_ID( PartyUnit.Protagonist, 3 ) != 1792 + 0 )
+
+                if (GET_EQUIPMENT_ID(PartyUnit.Protagonist, 3) != GET_CNT(242) && GET_EQUIPMENT_ID(PartyUnit.Protagonist, 3) != 1792 + 0)
                 {
                     CLOSE_MSG_WIN();
                 }
                 COStalk_SYSSET();
-                
-                if ( GET_CNT( 249 ) >= 5 )
+
+                if (GET_CNT(249) >= 5)
                 {
                     CLOSE_MSG_WIN();
                 }
 
-                FLD_FUNCTION_0047( var33 + 3, sVar7, sVar8, sVar9 );
+                FLD_FUNCTION_0047(var33 + 3, sVar7, sVar8, sVar9);
                 FLD_FUNCTION_0048();
             }
 
-            
-            if ( BIT_CHK( 0 + 0x0400 + 0x0800 + 136 ) == 0 )
+            if (BIT_CHK(0 + 0x0400 + 0x0800 + 136) == 0)
             {
-                
-                if ( var33 == 2 )
+
+                if (var33 == 2)
                 {
                     talk_helper_kuma();
                 }
-                else if ( var33 == 3 )
+                else if (var33 == 3)
                 {
                     talk_helper_rise();
                 }
-
             }
 
             goto _101;
         }
-        else if ( var33 == 4 )
+        else if (var33 == 4)
         {
             change_order();
             goto _101;
         }
 
-        else if ( var33 == 5 )
+        else if (var33 == 5)
         {
             CLOSE_MSG_WIN();
-            NAVI_BU_CLOSE( sVar7 );
-            BIT_ON( 0 + 0x0400 + 0x0800 + 95 );
+            NAVI_BU_CLOSE(sVar7);
+            BIT_ON(0 + 0x0400 + 0x0800 + 95);
             goto_stair();
             return;
         }
-        else if ( var33 == 6 || var33 == 7 )
+        else if (var33 == 6 || var33 == 7)
         {
             CLOSE_MSG_WIN();
-            NAVI_BU_CLOSE( sVar7 );
-            BIT_ON( 0 + 0x0400 + 0x0800 + 95 );
+            NAVI_BU_CLOSE(sVar7);
+            BIT_ON(0 + 0x0400 + 0x0800 + 95);
             backto_stair();
             return;
         }
-		// Select dungeon floor
-        else if ( var33 == 8 )
+        // Select dungeon floor
+        else if (var33 == 8)
         {
-			SelectFloor();
+            SelectFloor();
             goto _101;
         }
-		else if ( var33 == 9 )
-		{
-			use_gohom();
-            goto _101;
-		}
-		else if ( var33 == 10 )
-		{
-			CLOSE_MSG_WIN();
-			NAVI_BU_CLOSE( sVar7 );
-			use_fox();
-            goto _101;
-		}
-		else if ( var33 == 11 )
-		{
-			CLOSE_MSG_WIN();
-			NAVI_BU_CLOSE( sVar7 );
-			NS_SAVE();
-            goto _101;
-		}
-		else if ( var33 == 12 ) 
+        else if (var33 == 9)
         {
-			selected = false;
-			goto _101;
+            use_gohom();
+            goto _101;
         }
-		else if ( var33 == 18 )
-		{
-			CLOSE_MSG_WIN();
-			NAVI_BU_CLOSE( sVar7 );
-			MenuOptions();
-			options = true;
-			return;
-		}
-		
+        else if (var33 == 10)
+        {
+            CLOSE_MSG_WIN();
+            NAVI_BU_CLOSE(sVar7);
+            use_fox();
+            goto _101;
+        }
+        else if (var33 == 11)
+        {
+            CLOSE_MSG_WIN();
+            NAVI_BU_CLOSE(sVar7);
+            NS_SAVE();
+            goto _101;
+        }
+        else if (var33 == 12)
+        {
+            selected = false;
+            goto _101;
+        }
+        else if (var33 == 18)
+        {
+            CLOSE_MSG_WIN();
+            NAVI_BU_CLOSE(sVar7);
+            MenuOptions();
+            options = true;
+            return;
+        }
+
         goto _100;
     }
 
-    _101:
+_101:
     CLOSE_MSG_WIN();
-    
-    if ( sVar7 != 0 )
-    {
-        NAVI_BU_CLOSE( sVar7 );
-    }
 
+    if (sVar7 != 0)
+    {
+        NAVI_BU_CLOSE(sVar7);
+    }
 }
 
 void StrategizeMenu()
 {
-	SET_MASK( stratMask );
-	SEL_CHK_PAD( 14, 5 );
-	int selection = SEL( Strategize );
-	
-	if ( selection == 0 )
-	{
-		talk_member();
-		return;
-	}
-	else if ( selection == 1 || selection == 2 )
-	{
-		
-		if ( selection >= 1 && selection <= 2 && GET_FLOOR_ID() < 160 )
-		{
-			
-			if ( GET_EQUIPMENT_ID( PartyUnit.Protagonist, 3 ) != GET_CNT( 242 ) && GET_EQUIPMENT_ID( PartyUnit.Protagonist, 3 ) != 1792 + 0 )
-			{
-				CLOSE_MSG_WIN();
-			}
-			COStalk_SYSSET();
-			
-			if ( GET_CNT( 249 ) >= 5 )
-			{
-				CLOSE_MSG_WIN();
-			}
+    SET_MASK(stratMask);
+    SEL_CHK_PAD(14, 5);
+    int selection = SEL(Strategize);
 
-			FLD_FUNCTION_0047( selection + 4, sVar7, sVar8, sVar9 );
-			FLD_FUNCTION_0048();
-		}
+    if (selection == 0)
+    {
+        talk_member();
+        return;
+    }
+    else if (selection == 1 || selection == 2)
+    {
 
-		
-		if ( BIT_CHK( 0 + 0x0400 + 0x0800 + 136 ) == 0 )
-		{
-			
-			if ( selection == 1 )
-			{
-				talk_helper_kuma();
-			}
-			else if ( selection == 2 )
-			{
-				talk_helper_rise();
-			}
+        if (selection >= 1 && selection <= 2 && GET_FLOOR_ID() < 160)
+        {
 
-		}
+            if (GET_EQUIPMENT_ID(PartyUnit.Protagonist, 3) != GET_CNT(242) && GET_EQUIPMENT_ID(PartyUnit.Protagonist, 3) != 1792 + 0)
+            {
+                CLOSE_MSG_WIN();
+            }
+            COStalk_SYSSET();
 
-		return;
-	}
-	else if ( selection == 3 )
-	{
-		change_order();
-		return;
-	}
-	
-	else if ( selection == 4 )
-	{
-		OrganizeParty();
-		return;
-	}
+            if (GET_CNT(249) >= 5)
+            {
+                CLOSE_MSG_WIN();
+            }
 
+            FLD_FUNCTION_0047(selection + 4, sVar7, sVar8, sVar9);
+            FLD_FUNCTION_0048();
+        }
+
+        if (BIT_CHK(0 + 0x0400 + 0x0800 + 136) == 0)
+        {
+
+            if (selection == 1)
+            {
+                talk_helper_kuma();
+            }
+            else if (selection == 2)
+            {
+                talk_helper_rise();
+            }
+        }
+
+        return;
+    }
+    else if (selection == 3)
+    {
+        change_order();
+        return;
+    }
+
+    else if (selection == 4)
+    {
+        OrganizeParty();
+        return;
+    }
 }
 
 void init_sel_mask_hook()
 {
-	bool showDungeonOptions = BIT_CHK(6324);
+    bool showDungeonOptions = BIT_CHK(6324);
     bool showFox = BIT_CHK(6330);
     bool showFloorSelect = BIT_CHK(6331);
     bool showGohom = BIT_CHK(6332);
     bool showOrganizeParty = BIT_CHK(6333);
-	showFloorSelect = showFloorSelect && BeatDungeon();
+    showFloorSelect = showFloorSelect && BeatDungeon();
     int var34 = GET_FLOOR_ID();
     sVar0 = 0;
     sVar2 = 63;
     sVar3 = 127;
     sVar1 = 0;
     int var35 = 0;
-	stratMask = 0;
-	
-	// Decide to mask strategize menu
-	if (showDungeonOptions)
-		sVar1 = sVar1 + 30;
-	else
-		sVar1 = sVar1 + 1;
-	
-    _127:
-    
-    if ( var35 < 3 )
+    stratMask = 0;
+
+    // Decide to mask strategize menu
+    if (showDungeonOptions)
+        sVar1 = sVar1 + 30;
+    else
+        sVar1 = sVar1 + 1;
+
+_127:
+
+    if (var35 < 3)
     {
-        
-        if ( GET_PARTY_MEMBER_ID( var35 ) == 2 )
+
+        if (GET_PARTY_MEMBER_ID(var35) == 2)
         {
             sVar0 = sVar0 + 1;
             sVar2 = sVar2 - 1;
             sVar3 = sVar3 - 1;
         }
-        else if ( GET_PARTY_MEMBER_ID( var35 ) == 3 )
+        else if (GET_PARTY_MEMBER_ID(var35) == 3)
         {
             sVar0 = sVar0 + 1;
             sVar2 = sVar2 - 2;
             sVar3 = sVar3 - 2;
         }
-        else if ( GET_PARTY_MEMBER_ID( var35 ) == 4 )
+        else if (GET_PARTY_MEMBER_ID(var35) == 4)
         {
             sVar0 = sVar0 + 1;
             sVar2 = sVar2 - 4;
             sVar3 = sVar3 - 4;
         }
-        else if ( GET_PARTY_MEMBER_ID( var35 ) == 6 )
+        else if (GET_PARTY_MEMBER_ID(var35) == 6)
         {
             sVar0 = sVar0 + 1;
             sVar2 = sVar2 - 8;
             sVar3 = sVar3 - 8;
         }
-        else if ( GET_PARTY_MEMBER_ID( var35 ) == 7 )
+        else if (GET_PARTY_MEMBER_ID(var35) == 7)
         {
             sVar0 = sVar0 + 1;
             sVar2 = sVar2 - 0x10;
             sVar3 = sVar3 - 0x10;
         }
-        else if ( GET_PARTY_MEMBER_ID( var35 ) == 8 )
+        else if (GET_PARTY_MEMBER_ID(var35) == 8)
         {
             sVar0 = sVar0 + 1;
             sVar2 = sVar2 - 0x20;
@@ -388,93 +377,89 @@ void init_sel_mask_hook()
     }
 
     // No party members
-    if ( sVar0 == 0 )
+    if (sVar0 == 0)
     {
-		// Hide talk to others and change battle tactics
-		// 2 + 16
-		if (!showDungeonOptions)
-			sVar1 = sVar1 + 18;
-		else
-			stratMask = stratMask + 9;
+        // Hide talk to others and change battle tactics
+        // 2 + 16
+        if (!showDungeonOptions)
+            sVar1 = sVar1 + 18;
+        else
+            stratMask = stratMask + 9;
 
-        if ( BIT_CHK( 0 + 52 ) == 1 )
+        if (BIT_CHK(0 + 52) == 1)
         {
-			if (!showDungeonOptions)
-				sVar1 = sVar1 + 4;
-			else
-				stratMask = stratMask + 2;
+            if (!showDungeonOptions)
+                sVar1 = sVar1 + 4;
+            else
+                stratMask = stratMask + 2;
         }
-        else 
+        else
         {
-			if (!showDungeonOptions)
-				sVar1 = sVar1 + 8;
-			else
-				stratMask = stratMask + 4;
+            if (!showDungeonOptions)
+                sVar1 = sVar1 + 8;
+            else
+                stratMask = stratMask + 4;
         }
-
     }
-    else 
+    else
     {
-		// Hide Talk to teddie and rise
-		// 4 + 8
-		if (!showDungeonOptions)
-			sVar1 = sVar1 + 12;
-		else
-			stratMask = stratMask + 6;
+        // Hide Talk to teddie and rise
+        // 4 + 8
+        if (!showDungeonOptions)
+            sVar1 = sVar1 + 12;
+        else
+            stratMask = stratMask + 6;
 
-        if ( BIT_CHK( 0 + 52 ) == 1 )
+        if (BIT_CHK(0 + 52) == 1)
         {
             sVar3 = sVar3 - 0x40;
         }
-        else 
+        else
         {
             sVar3 = sVar3 - 0x20;
         }
-
     }
 
     // Hide Go to next floor if floor select is shown
-    if ( FLD_FUNCTION_0036() == 0 || showFloorSelect == true)
+    if (FLD_FUNCTION_0036() == 0 || showFloorSelect == true)
     {
         sVar1 = sVar1 + 32;
     }
 
-	// Mask return to previous floor and entrance
+    // Mask return to previous floor and entrance
     sVar1 = sVar1 + 192;
-    
-	// Keep Return to previous floor/entrance hidden if floor select is shown
-    if ( FLD_FUNCTION_0037() == 1 && showFloorSelect == false)
+
+    // Keep Return to previous floor/entrance hidden if floor select is shown
+    if (FLD_FUNCTION_0037() == 1 && showFloorSelect == false)
     {
         // Unmask entrance
-        if ( var34 == 6 || var34 == 21 || var34 == 41 || var34 == 61 || var34 == 81 || var34 == 101 || var34 == 121 || var34 == 123 || var34 == 141 || var34 == 161 )
+        if (var34 == 6 || var34 == 21 || var34 == 41 || var34 == 61 || var34 == 81 || var34 == 101 || var34 == 121 || var34 == 123 || var34 == 141 || var34 == 161)
         {
             sVar1 = sVar1 - 128;
         }
-		// Unmask floor
-        else 
+        // Unmask floor
+        else
         {
             sVar1 = sVar1 - 64;
         }
-
     }
-	
-	// Hide floor select
-	if (!showFloorSelect || !BIT_CHK(6324))
-		sVar1 = sVar1 + 256;
-	// Hide Goho-M
-	if (!showGohom || showFloorSelect || !BIT_CHK(6324) ||
-		( FLD_FUNCTION_0037() == 1 && 
-		( var34 == 6 || var34 == 21 || var34 == 41 || var34 == 61 || var34 == 81 || var34 == 101 
-		|| var34 == 121 || var34 == 123 || var34 == 141 || var34 == 161 )))
-		sVar1 = sVar1 + 512;
-	// Hide OrganizeParty
-	if (!EnableOrganizeParty() || !showOrganizeParty || !BIT_CHK(6324))
-		stratMask = stratMask + 16;
-	// Hide Call Fox
+
+    // Hide floor select
+    if (!showFloorSelect || !BIT_CHK(6324))
+        sVar1 = sVar1 + 256;
+    // Hide Goho-M
+    if (!showGohom || showFloorSelect || !BIT_CHK(6324) ||
+        (FLD_FUNCTION_0037() == 1 &&
+         (var34 == 6 || var34 == 21 || var34 == 41 || var34 == 61 || var34 == 81 || var34 == 101 || var34 == 121 || var34 == 123 || var34 == 141 || var34 == 161)))
+        sVar1 = sVar1 + 512;
+    // Hide OrganizeParty
+    if (!EnableOrganizeParty() || !showOrganizeParty || !BIT_CHK(6324))
+        stratMask = stratMask + 16;
+    // Hide Call Fox
     if (BIT_CHK(0 + 0x0400 + 0x0800 + 9) == 0 || !showFox || !BIT_CHK(6324) || (GET_FLOOR_ID() > 160 && GET_FLOOR_ID() < 180))
-		sVar1 = sVar1 + 1024;
-	if ( !BIT_CHK(6326) || saveAnywhere() )
-		sVar1 = sVar1 + 2048;
+        sVar1 = sVar1 + 1024;
+    if (!BIT_CHK(6326) || saveAnywhere())
+        sVar1 = sVar1 + 2048;
 }
 
 void tomb_jump_hook()
@@ -483,265 +468,258 @@ void tomb_jump_hook()
     int var25 = 0;
     var24 = var24 + 1 + 4 + 8;
     var24 = var24 + 0x20;
-	if (!EnableOrganizeParty() || !BIT_CHK(6324))
-		var24 = var24 + 2;
-	if (!BIT_CHK(6326) || saveAnywhere())
-		var24 = var24 + 64;
-    FUNCTION_0023( 0, 3 );
-    SEL_CHK_PAD( 14, 7 );
-	if (!BIT_CHK(6321))
-		SEL_CHK_PAD(12, 18);
-    int var23 = ADV_SEL( 12, TOMB_SEL_HOOK, var24 );
-    
-    if ( var23 == 0 || var23 == 2 || var23 == 3 || var23 == 4 )
+    if (!EnableOrganizeParty() || !BIT_CHK(6324))
+        var24 = var24 + 2;
+    if (!BIT_CHK(6326) || saveAnywhere())
+        var24 = var24 + 64;
+    FUNCTION_0023(0, 3);
+    SEL_CHK_PAD(14, 7);
+    if (!BIT_CHK(6321))
+        SEL_CHK_PAD(12, 18);
+    int var23 = ADV_SEL(12, TOMB_SEL_HOOK, var24);
+
+    if (var23 == 0 || var23 == 2 || var23 == 3 || var23 == 4)
     {
-        FADE( 1, 10 );
-        
-        if ( var23 == 4 )
+        FADE(1, 10);
+
+        if (var23 == 4)
         {
-            FUNCTION_0024( 255, 255, 255 );
+            FUNCTION_0024(255, 255, 255);
         }
 
         FADE_SYNC();
         FLD_FUNCTION_0024();
-        
-        if ( var23 == 0 )
+
+        if (var23 == 0)
         {
-            BIT_OFF( 0 + 0x0400 + 0x0800 + 2 );
-            CALL_DUNGEON( 1, 0 );
+            BIT_OFF(0 + 0x0400 + 0x0800 + 2);
+            CALL_DUNGEON(1, 0);
             return;
         }
-        else if ( var23 == 2 )
+        else if (var23 == 2)
         {
             DAIDARA_SHOP();
         }
-        else if ( var23 == 3 )
+        else if (var23 == 3)
         {
             SHIROKU_SHOP();
         }
-        else if ( var23 == 4 )
+        else if (var23 == 4)
         {
             var25 = 3;
             VELVET_ROOM();
-            BIT_OFF( 0 + 0x0400 + 719 );
+            BIT_OFF(0 + 0x0400 + 719);
         }
 
-        CALL_DUNGEON( 160, var25 );
+        CALL_DUNGEON(160, var25);
     }
-    else if ( var23 == 5 )
+    else if (var23 == 5)
     {
         OPEN_MSG_WIN();
-        MSG( RETURN_HOME_OK );
-        SEL_CHK_PAD( 14, 1 );
-        var23 = SEL( YESNO_SEL );
+        MSG(RETURN_HOME_OK);
+        SEL_CHK_PAD(14, 1);
+        var23 = SEL(YESNO_SEL);
         CLOSE_MSG_WIN();
-        
-        if ( var23 == 0 )
+
+        if (var23 == 0)
         {
             OPEN_MSG_WIN();
-            MSG( KUMA_BYE_TOMB );
+            MSG(KUMA_BYE_TOMB);
             CLOSE_MSG_WIN();
-            FADE( 1, 10 );
+            FADE(1, 10);
             FADE_SYNC();
             out_tv_world();
             return;
         }
-
     }
-	else if ( var23 == 1 )
+    else if (var23 == 1)
     {
-		OrganizeParty();
+        OrganizeParty();
     }
-	else if ( var23 == 6 )
-		NS_SAVE();
-	else if ( var23 == 18 )
-	{
-		MenuOptions();
-		options = true;
-	}
-	else
-		selected = false;
-
+    else if (var23 == 6)
+        NS_SAVE();
+    else if (var23 == 18)
+    {
+        MenuOptions();
+        options = true;
+    }
+    else
+        selected = false;
 }
 
 void liqueur_jump_hook()
 {
-    FUNCTION_0023( 0, 3 );
-	int mask = 0;
-	if (!EnableOrganizeParty() || !BIT_CHK(6324))
-		mask = mask + 2;
-	if (!BIT_CHK(6326) || saveAnywhere())
-		mask = mask + 4;
-    SEL_CHK_PAD( 14, 3 );
-	if (!BIT_CHK(6321))
-		SEL_CHK_PAD(12, 18);
-    int var26 = ADV_SEL( 15, LIQUEUR_SEL_HOOK, mask );
-    
-    if ( var26 == 0 )
+    FUNCTION_0023(0, 3);
+    int mask = 0;
+    if (!EnableOrganizeParty() || !BIT_CHK(6324))
+        mask = mask + 2;
+    if (!BIT_CHK(6326) || saveAnywhere())
+        mask = mask + 4;
+    SEL_CHK_PAD(14, 3);
+    if (!BIT_CHK(6321))
+        SEL_CHK_PAD(12, 18);
+    int var26 = ADV_SEL(15, LIQUEUR_SEL_HOOK, mask);
+
+    if (var26 == 0)
     {
         return_tv_studio();
     }
-	else if (var26 == 1)
-		OrganizeParty();
-	else if (var26 == 2)
-		NS_SAVE();
-	else if ( var26 == 18 )
-	{
-		MenuOptions();
-		options = true;
-	}
-	else
-		selected = false;
-
+    else if (var26 == 1)
+        OrganizeParty();
+    else if (var26 == 2)
+        NS_SAVE();
+    else if (var26 == 18)
+    {
+        MenuOptions();
+        options = true;
+    }
+    else
+        selected = false;
 }
 
 void studio_jump_hook()
 {
     int var22 = 0;
     int var21 = 0;
-    
-    if ( DATE_CHK( 2, 13 ) == 1 || DATE_CHK( 3, 20 ) == 1 )
+
+    if (DATE_CHK(2, 13) == 1 || DATE_CHK(3, 20) == 1)
     {
         var21 = var21 + 0x10;
         var21 = var21 + 1;
         var21 = var21 + 2 + 4;
     }
-    else 
+    else
     {
         var21 = var21 + 1 + 2 + 4;
     }
 
-    
-    if ( BIT_CHK( 0 + 0x0400 + 0x0800 + 0 ) == 0 )
+    if (BIT_CHK(0 + 0x0400 + 0x0800 + 0) == 0)
     {
         var21 = var21 + 128;
     }
 
-	if (!BIT_CHK(6326) || saveAnywhere())
-		var21 = var21 + 32;
+    if (!BIT_CHK(6326) || saveAnywhere())
+        var21 = var21 + 32;
 
-    FUNCTION_0023( 0, 3 );
-    SEL_CHK_PAD( 14, 6 );
-	if (!BIT_CHK(6321))SEL_CHK_PAD(12, 18);
-    int var20 = ADV_SEL( 3, SHOP_SEL_HOOK, var21 );
-    
-    if ( var20 == 0 || var20 == 1 || var20 == 2 || var20 == 3 )
+    FUNCTION_0023(0, 3);
+    SEL_CHK_PAD(14, 6);
+    if (!BIT_CHK(6321))
+        SEL_CHK_PAD(12, 18);
+    int var20 = ADV_SEL(3, SHOP_SEL_HOOK, var21);
+
+    if (var20 == 0 || var20 == 1 || var20 == 2 || var20 == 3)
     {
-        FADE( 1, 10 );
-        
-        if ( var20 == 3 )
+        FADE(1, 10);
+
+        if (var20 == 3)
         {
-            FUNCTION_0024( 255, 255, 255 );
+            FUNCTION_0024(255, 255, 255);
         }
 
         FADE_SYNC();
         FLD_FUNCTION_0024();
-        
-        if ( var20 == 0 )
+
+        if (var20 == 0)
         {
-            BIT_OFF( 0 + 0x0400 + 0x0800 + 2 );
-            CALL_DUNGEON( 160, 0 );
+            BIT_OFF(0 + 0x0400 + 0x0800 + 2);
+            CALL_DUNGEON(160, 0);
             return;
         }
-        else if ( var20 == 1 )
+        else if (var20 == 1)
         {
             DAIDARA_SHOP();
         }
-        else if ( var20 == 2 )
+        else if (var20 == 2)
         {
             SHIROKU_SHOP();
         }
-        else if ( var20 == 3 )
+        else if (var20 == 3)
         {
             var22 = 1;
             VELVET_ROOM();
-            BIT_OFF( 0 + 0x0400 + 719 );
+            BIT_OFF(0 + 0x0400 + 719);
         }
 
-        CALL_DUNGEON( 1, var22 );
+        CALL_DUNGEON(1, var22);
     }
-    else if ( var20 == 4 )
+    else if (var20 == 4)
     {
-        
-        if ( BIT_CHK( 0 + 0x0400 + 0x0800 + 6 ) == 0 )
+
+        if (BIT_CHK(0 + 0x0400 + 0x0800 + 6) == 0)
         {
-            HELP_MSG( 4 );
+            HELP_MSG(4);
         }
 
         OPEN_MSG_WIN();
-        MSG( RETURN_HOME_OK );
-        SEL_CHK_PAD( 14, 1 );
-        var20 = SEL( YESNO_SEL );
+        MSG(RETURN_HOME_OK);
+        SEL_CHK_PAD(14, 1);
+        var20 = SEL(YESNO_SEL);
         CLOSE_MSG_WIN();
-        
-        if ( var20 == 0 )
+
+        if (var20 == 0)
         {
-            
-            if ( BIT_CHK( 0 + 0x0400 + 0x0800 + 6 ) == 0 )
+
+            if (BIT_CHK(0 + 0x0400 + 0x0800 + 6) == 0)
             {
-                BIT_ON( 0 + 0x0400 + 0x0800 + 6 );
+                BIT_ON(0 + 0x0400 + 0x0800 + 6);
             }
 
             OPEN_MSG_WIN();
-            
-            if ( CHECK_TIME_SPAN( 4, 1, 7, 9 ) == 1 )
-            {
-                MSG( KUMA_BYE_1 );
-            }
-            else if ( CHECK_TIME_SPAN( 11, 6, 12, 7 ) == 1 )
-            {
-                
-                if ( BIT_CHK( 0 + 22 ) == 0 )
-                {
-                    MSG( KUMA_BYE_3 );
-                }
-                else if ( BIT_CHK( 0 + 22 ) == 1 )
-                {
-                    MSG( KUMA_BYE_4 );
-                }
 
-            }
-            else 
+            if (CHECK_TIME_SPAN(4, 1, 7, 9) == 1)
             {
-                MSG( KUMA_BYE_2 );
+                MSG(KUMA_BYE_1);
+            }
+            else if (CHECK_TIME_SPAN(11, 6, 12, 7) == 1)
+            {
+
+                if (BIT_CHK(0 + 22) == 0)
+                {
+                    MSG(KUMA_BYE_3);
+                }
+                else if (BIT_CHK(0 + 22) == 1)
+                {
+                    MSG(KUMA_BYE_4);
+                }
+            }
+            else
+            {
+                MSG(KUMA_BYE_2);
             }
 
             CLOSE_MSG_WIN();
-            FADE( 1, 10 );
+            FADE(1, 10);
             FADE_SYNC();
             out_tv_world();
             TV_STUDIO();
         }
-
     }
-	else if ( var20 == 5 )
-		NS_SAVE();
-	else if ( var20 == 6 )
-		selected = false;
-    else if ( var20 == 7 )
+    else if (var20 == 5)
+        NS_SAVE();
+    else if (var20 == 6)
+        selected = false;
+    else if (var20 == 7)
     {
-        SEL_CHK_PAD( 14, 2 );
-        var20 = ADV_SEL( 502, 503, 0 );
-        
-        if ( var20 == 0 )
-        {
-            FADE( 1, 10 );
-            FUNCTION_0024( 255, 255, 255 );
-            FADE_SYNC();
-            CALL_DUNGEON( 159, 0 );
-        }
-        else if ( var20 == 1 )
-        {
-            FADE( 1, 10 );
-            FADE_SYNC();
-            CALL_DUNGEON( 160, 0 );
-        }
+        SEL_CHK_PAD(14, 2);
+        var20 = ADV_SEL(502, 503, 0);
 
+        if (var20 == 0)
+        {
+            FADE(1, 10);
+            FUNCTION_0024(255, 255, 255);
+            FADE_SYNC();
+            CALL_DUNGEON(159, 0);
+        }
+        else if (var20 == 1)
+        {
+            FADE(1, 10);
+            FADE_SYNC();
+            CALL_DUNGEON(160, 0);
+        }
     }
-	else if ( var20 == 18 )
-	{
-		MenuOptions();
-		options = true;
-	}
-
+    else if (var20 == 18)
+    {
+        MenuOptions();
+        options = true;
+    }
 }

--- a/OtherMods/DungeonOptions/DungeonOptions.flow
+++ b/OtherMods/DungeonOptions/DungeonOptions.flow
@@ -101,6 +101,13 @@ void helper_order_hook()
 _100:
     int var33 = 0;
 
+    // If everything except the strategize and nevermind options are hidden just open the strategize menu
+    if (sVar1 == 2046)
+    {
+        StrategizeMenu();
+        goto _101;
+    }
+
     if (1)
     {
         // Set goho-m message variable
@@ -126,7 +133,7 @@ _100:
         SET_MASK(sVar1);
         if (!BIT_CHK(6321))
             SEL_CHK_PAD(12, 18);
-        SEL_CHK_PAD(14, 12);
+        SEL_CHK_PAD(14, 11);
         var33 = SEL(DUNGEON_SEL_HOOK);
 
         if (var33 == 0)
@@ -212,17 +219,10 @@ _100:
         {
             CLOSE_MSG_WIN();
             NAVI_BU_CLOSE(sVar7);
-            use_fox();
-            goto _101;
-        }
-        else if (var33 == 11)
-        {
-            CLOSE_MSG_WIN();
-            NAVI_BU_CLOSE(sVar7);
             NS_SAVE();
             goto _101;
         }
-        else if (var33 == 12)
+        else if (var33 == 11)
         {
             selected = false;
             goto _101;
@@ -251,7 +251,9 @@ _101:
 void StrategizeMenu()
 {
     SET_MASK(stratMask);
-    SEL_CHK_PAD(14, 5);
+    SEL_CHK_PAD(14, 6);
+    if (!BIT_CHK(6321))
+        SEL_CHK_PAD(12, 18);
     int selection = SEL(Strategize);
 
     if (selection == 0)
@@ -304,6 +306,20 @@ void StrategizeMenu()
     else if (selection == 4)
     {
         OrganizeParty();
+        return;
+    }
+    else if (selection == 5)
+    {
+        CLOSE_MSG_WIN();
+        NAVI_BU_CLOSE(sVar7);
+        use_fox();
+    }
+    else if (selection == 18)
+    {
+        CLOSE_MSG_WIN();
+        NAVI_BU_CLOSE(sVar7);
+        MenuOptions();
+        options = true;
         return;
     }
 }
@@ -457,9 +473,9 @@ _127:
         stratMask = stratMask + 16;
     // Hide Call Fox
     if (BIT_CHK(0 + 0x0400 + 0x0800 + 9) == 0 || !showFox || !BIT_CHK(6324) || (GET_FLOOR_ID() > 160 && GET_FLOOR_ID() < 180))
-        sVar1 = sVar1 + 1024;
+        stratMask = stratMask + 32;
     if (!BIT_CHK(6326) || saveAnywhere())
-        sVar1 = sVar1 + 2048;
+        sVar1 = sVar1 + 1024;
 }
 
 void tomb_jump_hook()

--- a/OtherMods/DungeonOptions/DungeonTravel.msg
+++ b/OtherMods/DungeonOptions/DungeonTravel.msg
@@ -20,11 +20,11 @@
 [f 0 5 -258][f 2 1]Talk to Teddie[e]
 [f 0 5 -258][f 2 1]Talk to Rise[e]
 [f 0 5 -258][f 2 1]Change battle tactics[e]
+[f 0 5 -258][f 2 1]Use a [f 2 5 3 -1 2] (×[f 2 4 1])[e]
 [f 0 5 -258][f 2 1]Move on to next floor[e]
 [f 0 5 -258][f 2 1]Return to previous floor[e]
 [f 0 5 -258][f 2 1]Return to entrance[e]
 [f 0 5 -258][f 2 1]Select floor[e]
-[f 0 5 -258][f 2 1]Use a [f 2 5 3 -1 2] (×[f 2 4 1])[e]
 [f 0 5 -258][f 2 1]Save[e]
 [f 0 5 -258][f 2 1]Nothing[e]
 

--- a/OtherMods/DungeonOptions/DungeonTravel.msg
+++ b/OtherMods/DungeonOptions/DungeonTravel.msg
@@ -24,7 +24,7 @@
 [f 0 5 -258][f 2 1]Return to previous floor[e]
 [f 0 5 -258][f 2 1]Return to entrance[e]
 [f 0 5 -258][f 2 1]Select floor[e]
-[f 0 5 -258][f 2 1][f 2 5 3 -1 2] × [f 2 4 1][e]
+[f 0 5 -258][f 2 1]Use a [f 2 5 3 -1 2] (×[f 2 4 1])[e]
 [f 0 5 -258][f 2 1]Call the fox[e]
 [f 0 5 -258][f 2 1]Save[e]
 [f 0 5 -258][f 2 1]Nothing[e]

--- a/OtherMods/DungeonOptions/DungeonTravel.msg
+++ b/OtherMods/DungeonOptions/DungeonTravel.msg
@@ -25,7 +25,6 @@
 [f 0 5 -258][f 2 1]Return to entrance[e]
 [f 0 5 -258][f 2 1]Select floor[e]
 [f 0 5 -258][f 2 1]Use a [f 2 5 3 -1 2] (×[f 2 4 1])[e]
-[f 0 5 -258][f 2 1]Call the fox[e]
 [f 0 5 -258][f 2 1]Save[e]
 [f 0 5 -258][f 2 1]Nothing[e]
 
@@ -45,6 +44,7 @@
 [f 0 5 -258][f 2 1]Talk to Rise[e]
 [f 0 5 -258][f 2 1]Change battle tactics[e]
 [f 0 5 -258][f 2 1]Organize party[e]
+[f 0 5 -258][f 2 1]Call the fox[e]
 [f 0 5 -258][f 2 1]Never mind[e]
 
 [sel YukikoFloors1]

--- a/OtherMods/DungeonOptions/DungeonTravel.msg
+++ b/OtherMods/DungeonOptions/DungeonTravel.msg
@@ -24,7 +24,7 @@
 [f 0 5 -258][f 2 1]Return to previous floor[e]
 [f 0 5 -258][f 2 1]Return to entrance[e]
 [f 0 5 -258][f 2 1]Select floor[e]
-[f 0 5 -258][f 2 1]Goho-M × [f 2 4 1][e]
+[f 0 5 -258][f 2 1][f 2 5 3 -1 2] × [f 2 4 1][e]
 [f 0 5 -258][f 2 1]Call the fox[e]
 [f 0 5 -258][f 2 1]Save[e]
 [f 0 5 -258][f 2 1]Nothing[e]

--- a/OtherMods/DungeonOptions/Fox.flow
+++ b/OtherMods/DungeonOptions/Fox.flow
@@ -3,8 +3,23 @@ import("Fox.msg");
 void use_fox()
 {
     int var1 = GET_FLOOR_ID();
+    bool inHollowForest = var1 > 160 && var1 < 180;
+    // Stop from using the fox at the end of magatsu inaba if using goho-m's is enabled as goho-m is disabled then
+    if (!inHollowForest && BIT_CHK(0 + 0x0400 + 0x0800 + 92) == 1 && BIT_CHK(0 + 0x0400 + 0x0800 + 93) == 0 && !BIT_CHK(6360))
+    {
+        PLAY_SOUNDEFFECT(241);
+        WAIT(10);
+        OPEN_MSG_WIN();
+        MSG(FOX_BAN);
+        CLOSE_MSG_WIN();
+        return;
+    }
+
     int var2 = GET_SL_LEVEL(13);
     int var3 = ADD_YEN(0);
+    // Get regular inventory yen if in hollow forest
+    if (inHollowForest)
+        var3 = ReadNumber(81684136, 4);
     int var11 = 1;
     int var7 = 0;
     int var12 = 0;
@@ -113,40 +128,53 @@ _16:
 
     OPEN_MSG_WIN();
 
-    if (var8 == 1)
-    {
-        MSG(FOX_TALK_BAD);
-    }
-    else if (var8 == 0 || var8 == 2)
-    {
-        MSG(FOX_TALK_NORMAL);
-    }
-    else if (var8 == 3)
-    {
-        MSG(FOX_TALK_GOOD);
-    }
-
-    OPEN_MSG_WIN();
-
     if (var4 == 0)
     {
         MSG(RECOVER_NOT_NEED);
     }
     else
     {
-        SET_MSG_VAR(0, var4, 0);
-        SET_MSG_VAR(1, var3, 0);
-        MSG(RECOVER_OK);
-
         // Check if they have any goho-m or equal items
+        bool needGohom = !BIT_CHK(6360);
         int gohom = GET_ITEM(790);
         int retDaikon = GET_ITEM(2099);
-        if (gohom == 0 && retDaikon == 0)
+        int branch = GET_ITEM(885);
+        if (inHollowForest && branch == 0)
+        {
+            SET_MSG_VAR(0, 885, 1);
+            MSG(NEED_BRANCH);
+            return;
+        }
+        else if (!inHollowForest && needGohom && gohom == 0 && retDaikon == 0)
         {
             SET_MSG_VAR(0, 790, 1);
             SET_MSG_VAR(1, 2099, 1);
             MSG(NEED_GOHOM);
             return;
+        }
+
+        // Display correct recover message (either with or without goho-m)
+        SET_MSG_VAR(0, var4, 0);
+        SET_MSG_VAR(1, var3, 0);
+
+        if (needGohom)
+        {
+            // Display goho-m recovery message
+            if (inHollowForest)
+            {
+                SET_MSG_VAR(3, branch, 0);
+                SET_MSG_VAR(2, 885, 1);
+            }
+            else
+            {
+                SET_MSG_VAR(3, gohom + retDaikon, 0);
+                SET_MSG_VAR(2, 790, 1);
+            }
+            MSG(RECOVER_OK_GOHOM);
+        }
+        else
+        {
+            MSG(RECOVER_OK);
         }
 
         // Check if they want to pay
@@ -162,21 +190,60 @@ _16:
             }
             else
             {
-                if (gohom != 0)
+                // Fox animation
+                FADE(1, 10);
+                FADE_SYNC();
+                MSG(FOX_CALL);
+                PLAY_SOUNDEFFECT(512);
+                MSG(FOX_CALL_2);
+                FUNCTION_0015(15);
+                FADE_SYNC();
+
+                if (var8 == 1)
                 {
-                    SET_ITEM(790, gohom - 1);
-                    SET_MSG_VAR(0, 790, 1);
+                    MSG(FOX_TALK_BAD);
+                }
+                else if (var8 == 0 || var8 == 2)
+                {
+                    MSG(FOX_TALK_NORMAL);
+                }
+                else if (var8 == 3)
+                {
+                    MSG(FOX_TALK_GOOD);
+                }
+
+                // Actual healing and paying stuff
+                // If use gohom is enabled use it
+                if (needGohom)
+                {
+                    if (inHollowForest)
+                    {
+                        SET_ITEM(885, branch - 1);
+                        SET_MSG_VAR(0, 885, 1);
+                    }
+                    else if (gohom != 0)
+                    {
+                        SET_ITEM(790, gohom - 1);
+                        SET_MSG_VAR(0, 790, 1);
+                    }
+                    else
+                    {
+                        SET_ITEM(2099, retDaikon - 1);
+                        SET_MSG_VAR(0, 2099, 1);
+                    }
+                }
+
+                var4 = var4 * -1;
+                // Take yen from the regular inventory
+                if (inHollowForest)
+                {
+                    WriteNumber(81684136, 4, var3 + var4);
+                    WriteNumber(81725936, 4, var3 + var4);
                 }
                 else
                 {
-                    SET_ITEM(2099, retDaikon - 1);
-                    SET_MSG_VAR(0, 2099, 1);
+                    ADD_YEN(var4);
                 }
-
-                MSG(ITEM_USED);
-
-                var4 = var4 * -1;
-                ADD_YEN(var4);
                 MSG(RECOVER_START);
                 CLOSE_MSG_WIN();
                 WAIT(10);

--- a/OtherMods/DungeonOptions/Fox.flow
+++ b/OtherMods/DungeonOptions/Fox.flow
@@ -135,11 +135,24 @@ void use_fox()
 	}
 	else 
 	{
-		SET_MSG_VAR( 0, var4, 0 );
-		SET_MSG_VAR( 1, var3, 0 );
-		MSG( RECOVER_OK );
-		SEL_CHK_PAD( 14, 1 );
-		int var0 = SEL( PAY_SEL );
+        SET_MSG_VAR(0, var4, 0);
+        SET_MSG_VAR(1, var3, 0);
+        MSG(RECOVER_OK);
+
+        // Check if they have any goho-m or equal items
+        int gohom = GET_ITEM(790);
+        int retDaikon = GET_ITEM(2099);
+        if (gohom == 0 && retDaikon == 0)
+        {
+            SET_MSG_VAR(0, 790, 1);
+            SET_MSG_VAR(1, 2099, 1);
+            MSG(NEED_GOHOM);
+            return;
+        }
+
+        // Check if they want to pay
+        SEL_CHK_PAD(14, 1);
+        int var0 = SEL(PAY_SEL);
 		
 		if ( var0 == 0 )
 		{
@@ -150,6 +163,18 @@ void use_fox()
 			}
 			else 
 			{
+                if (gohom != 0)
+                {
+                    SET_ITEM(790, gohom - 1);
+                    SET_MSG_VAR(0, 790, 1);
+                }
+                else
+                {
+                    SET_ITEM(2099, retDaikon - 1);
+                    SET_MSG_VAR(0, 2099, 1);
+                }
+
+                MSG(ITEM_USED);
 				var4 = var4 * -1;
 				ADD_YEN( var4 );
 				MSG( RECOVER_START );

--- a/OtherMods/DungeonOptions/Fox.flow
+++ b/OtherMods/DungeonOptions/Fox.flow
@@ -3,88 +3,88 @@ import("Fox.msg");
 void use_fox()
 {
     int var1 = GET_FLOOR_ID();
-    int var2 = GET_SL_LEVEL( 13 );
-    int var3 = ADD_YEN( 0 );
+    int var2 = GET_SL_LEVEL(13);
+    int var3 = ADD_YEN(0);
     int var11 = 1;
     int var7 = 0;
     int var12 = 0;
-    
-    if ( var2 == 1 )
+
+    if (var2 == 1)
     {
         var7 = 60;
     }
-    else if ( var2 == 2 )
+    else if (var2 == 2)
     {
         var7 = 55;
     }
-    else if ( var2 == 3 )
+    else if (var2 == 3)
     {
         var7 = 50;
     }
-    else if ( var2 == 4 )
+    else if (var2 == 4)
     {
         var7 = 45;
     }
-    else if ( var2 == 5 )
+    else if (var2 == 5)
     {
         var7 = 40;
     }
-    else if ( var2 == 6 )
+    else if (var2 == 6)
     {
         var7 = 35;
     }
-    else if ( var2 == 7 )
+    else if (var2 == 7)
     {
         var7 = 30;
     }
-    else if ( var2 == 8 )
+    else if (var2 == 8)
     {
         var7 = 25;
     }
-    else if ( var2 == 9 )
+    else if (var2 == 9)
     {
         var7 = 20;
     }
-    else if ( var2 == 10 )
+    else if (var2 == 10)
     {
         var7 = 15;
     }
-    else 
+    else
     {
         var7 = 100;
     }
 
     int var8 = GET_MONTH() + GET_DAY_OF_MONTH();
-    _12:
-    
-    if ( var8 >= 4 )
+_12:
+
+    if (var8 >= 4)
     {
         var8 = var8 - 4;
         goto _12;
     }
 
     int var9 = GET_DAY_OF_MONTH();
-    _14:
-    
-    if ( var9 >= 10 )
+_14:
+
+    if (var9 >= 10)
     {
         var9 = var9 - 10;
         goto _14;
     }
 
-    int var5 = GET_CUR_SP( 1 );
-    int var6 = GET_TOT_SP( 1 );
+    int var5 = GET_CUR_SP(1);
+    int var6 = GET_TOT_SP(1);
     int var10 = 0;
-    _16:
-    
-    if ( var10 < 3 )
+_16:
+
+    if (var10 < 3)
     {
-        var11 = GET_PARTY_MEMBER_ID( var10 );
-        
-        if ( var11 != 0 )
+        var11 = GET_PARTY_MEMBER_ID(var10);
+
+        if (var11 != 0)
         {
-            var5 = var5 + GET_CUR_SP( var11 );
-            var6 = var6 + GET_TOT_SP( var11 );
+            var5 = var5 + GET_CUR_SP(var11);
+            var6 = var6 + GET_TOT_SP(var11);
         }
 
         var10 = var10 + 1;
@@ -92,49 +92,48 @@ void use_fox()
     }
 
     int var4 = (var6 - var5) * var7;
-    
-    if ( var8 == 1 )
+
+    if (var8 == 1)
     {
         var4 = var4 * 1.50f;
     }
-    else if ( var8 == 0 || var8 == 2 )
+    else if (var8 == 0 || var8 == 2)
     {
         var4 = var4 * 1;
     }
-    else if ( var8 == 3 )
+    else if (var8 == 3)
     {
         var4 = var4 * 0.70f;
     }
 
-    
-    if ( var4 > 9999999 )
+    if (var4 > 9999999)
     {
         var4 = 9999999;
     }
 
     OPEN_MSG_WIN();
-    
-    if ( var8 == 1 )
+
+    if (var8 == 1)
     {
-        MSG( FOX_TALK_BAD );
+        MSG(FOX_TALK_BAD);
     }
-    else if ( var8 == 0 || var8 == 2 )
+    else if (var8 == 0 || var8 == 2)
     {
-        MSG( FOX_TALK_NORMAL );
+        MSG(FOX_TALK_NORMAL);
     }
-    else if ( var8 == 3 )
+    else if (var8 == 3)
     {
-        MSG( FOX_TALK_GOOD );
+        MSG(FOX_TALK_GOOD);
     }
-    
-	OPEN_MSG_WIN();
-	
-	if ( var4 == 0 )
-	{
-		MSG( RECOVER_NOT_NEED );
-	}
-	else 
-	{
+
+    OPEN_MSG_WIN();
+
+    if (var4 == 0)
+    {
+        MSG(RECOVER_NOT_NEED);
+    }
+    else
+    {
         SET_MSG_VAR(0, var4, 0);
         SET_MSG_VAR(1, var3, 0);
         MSG(RECOVER_OK);
@@ -153,16 +152,16 @@ void use_fox()
         // Check if they want to pay
         SEL_CHK_PAD(14, 1);
         int var0 = SEL(PAY_SEL);
-		
-		if ( var0 == 0 )
-		{
-			
-			if ( var4 > var3 )
-			{
-				MSG( RECOVER_NO_MONEY );
-			}
-			else 
-			{
+
+        if (var0 == 0)
+        {
+
+            if (var4 > var3)
+            {
+                MSG(RECOVER_NO_MONEY);
+            }
+            else
+            {
                 if (gohom != 0)
                 {
                     SET_ITEM(790, gohom - 1);
@@ -175,52 +174,47 @@ void use_fox()
                 }
 
                 MSG(ITEM_USED);
-				var4 = var4 * -1;
-				ADD_YEN( var4 );
-				MSG( RECOVER_START );
-				CLOSE_MSG_WIN();
-				WAIT( 10 );
-				recovery_SP();
-				OPEN_MSG_WIN();
-				MSG( RECOVER_DONE );
-			}
 
-		}
-
-	}
-
-	CLOSE_MSG_WIN();
-
+                var4 = var4 * -1;
+                ADD_YEN(var4);
+                MSG(RECOVER_START);
+                CLOSE_MSG_WIN();
+                WAIT(10);
+                recovery_SP();
+                OPEN_MSG_WIN();
+                MSG(RECOVER_DONE);
+            }
+        }
+    }
+    CLOSE_MSG_WIN();
 }
-
 
 void recovery_SP()
 {
-    FUNCTION_006D( 5, 9 );
-    FADE( 1, 5 );
-    FUNCTION_0024( 255, 255, 255 );
+    FUNCTION_006D(5, 9);
+    FADE(1, 5);
+    FUNCTION_0024(255, 255, 255);
     FADE_SYNC();
-    int var16 = GET_TOT_SP( 1 );
-    SET_SP( 1, var16 );
+    int var16 = GET_TOT_SP(1);
+    SET_SP(1, var16);
     int var14 = 0;
-    _65:
+_65:
     int var15 = 0;
-    
-    if ( var14 < 3 )
+
+    if (var14 < 3)
     {
-        var15 = GET_PARTY_MEMBER_ID( var14 );
-        
-        if ( var15 != 0 )
+        var15 = GET_PARTY_MEMBER_ID(var14);
+
+        if (var15 != 0)
         {
-            var16 = GET_TOT_SP( var15 );
-            SET_SP( var15, var16 );
+            var16 = GET_TOT_SP(var15);
+            SET_SP(var15, var16);
         }
 
         var14 = var14 + 1;
         goto _65;
     }
 
-    FUNCTION_0015( 15 );
+    FUNCTION_0015(15);
     FADE_SYNC();
 }
-

--- a/OtherMods/DungeonOptions/Fox.msg
+++ b/OtherMods/DungeonOptions/Fox.msg
@@ -7,8 +7,14 @@
 [f 0 5 -258][f 2 1]Don't pay[e]
 
 [msg NEED_GOHOM]
-[f 0 5 -258][f 2 1]> However, you need a [f 2 5 3 -1 0] or 
-[n][f 2 5 3 -1 1] to call the fox.[n][f 1 1][e]
+[f 0 5 -258][f 2 1]> You don't have a [f 2 5 3 -1 0] or [f 2 5 3 -1 1]...[n][f 1 1][e]
+[f 0 5 -258][f 2 1]> It's too dangerous to call the fox without[n]
+an item that can return it to safety.[n][f 1 1][e]
+
+[msg NEED_BRANCH]
+[f 0 5 -258][f 2 1]> You don't have a [f 2 5 3 -1 0]...[n][f 1 1][e]
+[f 0 5 -258][f 2 1]> It's too dangerous to call the fox without[n]
+an item that can return it to safety.[n][f 1 1][e]
 
 [msg ITEM_USED]
 [f 0 5 -258][f 2 1]> Used 1 [f 2 5 3 -1 0].[n][f 1 1][e]
@@ -57,6 +63,10 @@
 [msg RECOVER_OK]
 [f 0 5 -258][f 2 1]> It seems you need [f 0 1 1][f 2 4 0] yen[f 0 1 0][n]for healing...[n]   (You currently have: [f 0 1 1][f 2 4 1] yen[f 0 1 0])[n][f 1 1][e]
 
+[msg RECOVER_OK_GOHOM]
+[f 0 5 -258][f 2 1]> It seems you need [f 0 1 1][f 2 4 0] yen[f 0 1 0] and [f 0 1 3]1 [f 2 5 3 -1 2][f 0 1 0]
+[n]for healing...[n]   (You currently have: [f 0 1 1][f 2 4 1] yen[f 0 1 0] and [f 0 1 3][f 2 4 3] [f 2 5 3 -1 2][f 0 1 0])[n][f 1 1][e]
+
 [msg RECOVER_NOT_NEED]
 [f 0 5 -258][f 2 1]> You don't need healing right now...[n][f 1 1][e]
 
@@ -68,9 +78,20 @@
 
 [msg RECOVER_DONE]
 [f 0 5 -258][f 2 1]> Everyone's SP has been recovered![n][f 1 1][e]
+[f 0 5 -258][f 2 1]> The fox retreated.[n][f 1 1][e]
 
 [msg FOX_GIFT [Fox]]
 [f 0 5 -258][f 2 1][f 4 6 9 1 0 1]*yip*[n][f 1 1][e]
 
 [msg GET_ITEM_FOX]
 [f 0 5 -258][f 2 1]> The fox gave you[n][f 2 5 3 -1 0] x [f 2 4 1].[n][f 1 1][e]
+
+[msg FOX_BAN]
+[f 0 5 -258][f 2 1]> Something is preventing you from[n]calling the fox...[n][f 1 1][e]
+
+[msg FOX_CALL]
+[f 0 5 -258][f 2 1]> You called for the fox.[n][f 1 1][e]
+[f 0 5 -258][f 2 1]> ...[n][f 1 1][e]
+
+[msg FOX_CALL_2]
+[f 0 5 -258][f 2 1]> ...![n][f 1 1][e]

--- a/OtherMods/DungeonOptions/Fox.msg
+++ b/OtherMods/DungeonOptions/Fox.msg
@@ -6,6 +6,13 @@
 [f 0 5 -258][f 2 1]Pay[e]
 [f 0 5 -258][f 2 1]Don't pay[e]
 
+[msg NEED_GOHOM]
+[f 0 5 -258][f 2 1]> However, you need a [f 2 5 3 -1 0] or 
+[n][f 2 5 3 -1 1] to call the fox.[n][f 1 1][e]
+
+[msg ITEM_USED]
+[f 0 5 -258][f 2 1]> Used 1 [f 2 5 3 -1 0].[n][f 1 1][e]
+
 [msg FOX_FIRST_BAD]
 [f 0 5 -258][f 2 1]> It followed you all the way here[n]after all...[n][f 1 1][e]
 [f 0 5 -258][f 2 1]> The strange atmosphere seems to be[n]making him uncomfortable...[n][f 1 1][e]

--- a/OtherMods/DungeonOptions/GohoM.flow
+++ b/OtherMods/DungeonOptions/GohoM.flow
@@ -2,8 +2,12 @@ import("GohoM.msg");
 
 void use_gohom()
 {
+    int var17 = GET_FLOOR_ID();
+    int var18 = GET_FLOOR_ID();
 	bool ConsistentReaper = BIT_CHK(6328);
-	if (GET_ITEM(790) == 0 && GET_ITEM(2099) == 0)
+    bool inHollowForest = var17 > 160 && var17 < 180;
+
+    if ((!inHollowForest && GET_ITEM(790) == 0 && GET_ITEM(2099) == 0) || (inHollowForest && GET_ITEM(885) == 0))
 	{
 		NAVI_BU_CLOSE( sVar7 );
 		sVar7 = NAVI_BU_OPEN( 280, -40, sVar8, sVar9 + 3 );
@@ -13,7 +17,8 @@ void use_gohom()
 		}
 		else
 		{
-			MSG(NoMoreTeddie);
+            SET_MSG_VAR(0, 790, 1);
+            MSG(NoMoreTeddie);
 		}
 		CLOSE_MSG_WIN();
 		return;
@@ -21,11 +26,23 @@ void use_gohom()
 	
 	if (sVar8 == 5)
 	{
-		MSG(ConfirmGohomRise);
+        // Display the item to be used
+        if(inHollowForest)
+            SET_MSG_VAR(0, 885, 1);
+        else if(GET_ITEM(790) != 0)
+            SET_MSG_VAR(0, 790, 1);
+        else
+            SET_MSG_VAR(0, 2099, 1);
+        MSG(ConfirmGohomRise);
 	}
 	else
 	{
-		MSG(ConfirmGohomTeddie);
+        // Display the item to be used
+        if(GET_ITEM(790) != 0)
+            SET_MSG_VAR(0, 790, 1);
+        else
+            SET_MSG_VAR(0, 2099, 1);
+        MSG(ConfirmGohomTeddie);
 	}
 	SEL_CHK_PAD( 14, 1 );
 	int confirm = SEL(YesNo);
@@ -34,10 +51,9 @@ void use_gohom()
 	if (confirm == 1)
 		return;
 	
-    int var17 = GET_FLOOR_ID();
-    int var18 = GET_FLOOR_ID();
     
-    if ( BIT_CHK( 0 + 0x0400 + 0x0800 + 92 ) == 1 && BIT_CHK( 0 + 0x0400 + 0x0800 + 93 ) == 0 )
+    // Ignore this check if in hollow forest
+    if (!(var17 > 160 && var17 < 180) && BIT_CHK( 0 + 0x0400 + 0x0800 + 92 ) == 1 && BIT_CHK( 0 + 0x0400 + 0x0800 + 93 ) == 0 )
     {
         WAIT( 10 );
         PLAY_SOUNDEFFECT( 241 );
@@ -59,10 +75,14 @@ void use_gohom()
         BIT_OFF( 0 + 0x0400 + 0x0800 + 47 );
     }
 	
-	if (GET_ITEM(790) > 0)
+    // Use the return item
+    if(inHollowForest)
+        SET_ITEM(885, GET_ITEM(885) - 1);
+	else if (GET_ITEM(790) > 0)
 		SET_ITEM(790, GET_ITEM(790) - 1);
     else if (GET_ITEM(2099) > 0)
 		SET_ITEM(2099, GET_ITEM(2099) - 1);
+
     if ( FLD_FUNCTION_0036() == 1 && FLD_FUNCTION_0037() == 0 )
     {
         var18 = var18 + 1;

--- a/OtherMods/DungeonOptions/GohoM.msg
+++ b/OtherMods/DungeonOptions/GohoM.msg
@@ -2,14 +2,14 @@
 [f 0 5 -258][f 2 1]> Something is preventing it from[n]working...[n][f 1 1][e]
 
 [msg ConfirmGohomRise [Rise]]
-[f 0 5 -258][f 2 1]Use a Goho-M/Return Daikon and return to the entrance?[n][e]
+[f 0 5 -258][f 2 1]Use a [f 2 5 3 -1 0] and return to the entrance?[n][e]
 
 [msg ConfirmGohomTeddie [Teddie]]
-[f 0 5 -258][f 2 1]Use a Goho-M/Return Daikon and return to the entrance?[n][e]
+[f 0 5 -258][f 2 1]Use a [f 2 5 3 -1 0] and return to the entrance?[n][e]
 
 [msg NoMoreRise [Rise]]
 [f 0 5 -258][f 2 1]Looks like you're all out, Senpai.[n]Let's find another way back.[n][f 1 1][e]
 
 [msg NoMoreTeddie [Teddie]]
-[f 0 5 -258][f 2 1]Wahhh... Sensei, your Goho-M[n]stash is looking bear![n][f 1 1][e]
+[f 0 5 -258][f 2 1]Wahhh... Sensei, your [f 2 5 3 -1 0][n]stash is looking bear![n][f 1 1][e]
 

--- a/OtherMods/DungeonOptions/OrganizeParty.flow
+++ b/OtherMods/DungeonOptions/OrganizeParty.flow
@@ -428,6 +428,10 @@ int ChooseMember(int text, int mask)
 
 bool EnableOrganizeParty()
 {
+	// You can't switch party members until after you've saved Yukiko
+	if (CHECK_TIME_SPAN(4, 10, 4, 30) && BIT_CHK(0 + 0x0400 + 1569))
+		return false;
+
 	int availableMembers = 0;
 	if (CHECK_TIME_SPAN(4,10,4,17) == 0)
 		availableMembers = availableMembers + 1;

--- a/Setup/FirstTimeSetup.flow
+++ b/Setup/FirstTimeSetup.flow
@@ -106,7 +106,7 @@ void MenuOptions()
 	}
 }
 
-void ToggleOption(int startMsg, int startFlag, int selection, bool subOption)
+bool ToggleOption(int startMsg, int startFlag, int selection, bool subOption)
 {
 	OPEN_MSG_WIN();
 	MSG(startMsg + selection);
@@ -159,6 +159,7 @@ void ToggleOption(int startMsg, int startFlag, int selection, bool subOption)
 		break;
 	}
 	CLOSE_MSG_WIN();
+	return sel;
 }
 
 void FindAFriendOptionsToggle()
@@ -222,7 +223,52 @@ void DungeonOptionsToggle()
 		int selection = ADV_SEL(DungeonOptions_Text, DungeonOptions, 0);
 		if (selection != 4)
 		{
-			ToggleOption(ShowFox_About, 6330, selection, true);
+			bool optionSel = ToggleOption(ShowFox_About, 6330, selection, true);
+			// If show fox was selected
+			if (selection == 0)
+			{
+				// Reset fox uses goho-m flag if call fox was turned off
+				if (optionSel == 1)
+				{
+					BIT_OFF(6360);
+				}
+				else if (optionSel == 0)
+				{
+					bool done2 = false;
+					while (!done2)
+					{
+						// If call fox was turned on show selection for whether calling the fox should us a goho-m
+						SET_MSG_VAR(0, 620 - BIT_CHK(6360), 6);
+						SEL_CHK_PAD(14, 1);
+						SEL_CHK_PAD(15, 1);
+						OPEN_MSG_WIN();
+						int foxSel = ADV_SEL(ShowFoxOptions_Text, ShowFoxOptions, 0);
+						// Toggle the option
+						if (foxSel == 0)
+						{
+							SET_MSG_VAR(2, 790, 1);
+							SET_MSG_VAR(3, 2099, 1);
+							OPEN_MSG_WIN();
+							MSG(ShowFox_GohoM);
+							SEL_CHK_PAD(14, 2);
+							SEL_CHK_PAD(15, 2);
+							int gohomSel = SEL(ToggleMenu);
+							//
+							if (gohomSel == 0)
+							{
+								BIT_OFF(6360);
+							}
+							else if (gohomSel == 1)
+							{
+								BIT_ON(6360);
+							}
+						} else {
+							done2 = true;
+						}
+						CLOSE_MSG_WIN();
+					}
+				}
+			}
 		}
 		else
 		{

--- a/Setup/FirstTimeSetup.msg
+++ b/Setup/FirstTimeSetup.msg
@@ -175,3 +175,15 @@
 [f 0 5 -258][f 2 1]Would you like to skip the story exposition
 [n]and start from April 20? This is not recommended
 [n]for first-time players.[f 1 1][e]
+
+[msg ShowFoxOptions_Text]
+[f 0 5 -258][f 2 1]Show Fox Option[e]
+
+[sel ShowFoxOptions]
+[f 0 5 -258][f 2 1]Use Goho-M: [f 2 4 0][e]
+[f 0 5 -258][f 2 1]Done[e]
+
+[msg ShowFox_GohoM[Fox Goho-M (Tekka)]]
+[f 0 5 -258][f 2 1]If "On", when calling the fox
+[n]a [f 2 5 3 -1 2] or [f 2 5 3 -1 3] 
+[n]will be used if you pay for healing.[e]

--- a/Setup/FirstTimeSetup.msg
+++ b/Setup/FirstTimeSetup.msg
@@ -184,6 +184,6 @@
 [f 0 5 -258][f 2 1]Done[e]
 
 [msg ShowFox_GohoM[Fox Goho-M (Tekka)]]
-[f 0 5 -258][f 2 1]If "On", when calling the fox
-[n]a [f 2 5 3 -1 2] or [f 2 5 3 -1 3] 
-[n]will be used if you pay for healing.[e]
+[f 0 5 -258][f 2 1]A tweak designed to improve balance. If "On", 
+[n]calling the fox will additionally require 
+[n]a [f 2 5 3 -1 2] or [f 2 5 3 -1 3].[e]

--- a/field/f007.bf.flow
+++ b/field/f007.bf.flow
@@ -86,7 +86,7 @@ void check_bike_hook()
         else if ( var109 == 1 )
         {
             
-            if ( ( GET_CNT( 62 ) < ( 2 + 1 ) ) && ( FUNCTION_0044( 0 ) < 3 ) )
+            if ( ( GET_CNT( 62 ) < ( 2 + 1 ) ) && ( GET_SOCIAL_STAT_LEVEL( 0 ) < 3 ) )
             {
                 MSG( BIKE_FAR_STOP );
             }
@@ -94,7 +94,7 @@ void check_bike_hook()
             {
                 MSG( BIKE_FAR_STOP_NEAR_NG );
             }
-            else if ( FUNCTION_0044( 0 ) < 3 )
+            else if ( GET_SOCIAL_STAT_LEVEL( 0 ) < 3 )
             {
                 MSG( BIKE_FAR_STOP_YUUKI_NG );
             }


### PR DESCRIPTION
### Two Things To Note
1. [This](https://github.com/ShrineFox/Persona-4-Golden-Mod-Menu/files/7026377/Persona4Golden.Library.zip) updated p4g library is required as I renamed a few unnamed functions (and haven't added them to the repo yet).
2. A version of this that should be ready for CEP is available on the [CEP branch](https://github.com/AnimatedSwine37/Persona-4-Golden-Mod-Menu/tree/CEP) of my fork.

### Additions and Changes
- Adds option to make calling the fox use a goho-m/return daikon
   - On by default but can be changed in the options
- Adds small "cutscene" when the fox is called
- Allows sacred branch to be used from the dungeon menu in the hollow forest (the equivalent of a goho-m)
- Fix being able to use a goho-m on some of the last floors of Magatsu Inaba when it should have been blocked
- Alters text referencing items to include the item icon
- Adds a help message the first time players get the reaper's chain rattling if using consistent reaper
- Adds edit count option to flag menu
- Adds edit memory option to flag menu
   - This can read and write to "any" location in the games memory using BIT_CHK, ON and OFF 
   - The functions for this are available in Utilities.flow and anyone is free to copy and use in their own flowscript mods (with credit preferably)
- Other misc fixes to the mod menu like the BGM number getting 9 digits when the text said it got 5