### PR TITLE
Fix Sound Not Playing When Opening Sub Menu

### DIFF
--- a/OtherMods/QuickTravelPlus.flow
+++ b/OtherMods/QuickTravelPlus.flow
@@ -13,6 +13,9 @@ bool saveAnywhere()
 
 void field_order_hook()
 {
+	// Play the sub menu opening sound
+	FUNCTION_0023( 0, 3 );
+
 	bool calendar = BIT_CHK(6323);
 	bool friend = BIT_CHK(6325);
 	bool plus = BIT_CHK(6322);


### PR DESCRIPTION
When opening the sub menu a sound plays, this was broken when opening it in the overworld in one of the past updates (not sure which one). Now it's fixed