### PR TITLE
Softlock Fixes

### DIFF
--- a/OtherMods/ConsistentReaper.flow
+++ b/OtherMods/ConsistentReaper.flow
@@ -499,5 +499,8 @@ void dng_escape_hook()
     {
         CALL_DUNGEON( 160, 1 );
     }
-
+    else 
+    {
+        CALL_DUNGEON( 5, 1 ); // Yukiko's castle entrance in case we can't find the dungeon
+    }
 }

--- a/OtherMods/DungeonOptions/DungeonError.msg
+++ b/OtherMods/DungeonOptions/DungeonError.msg
@@ -1,0 +1,3 @@
+[msg GOHOM_ERROR]
+[f 0 5 65278][f 2 1]Unable to determine what dungeon you are in[n]going to Yukiko's Castle as a fallback.[n][f 1 1][e]
+[f 0 5 65278][f 2 1]Please report this bug with the information[n]that the floor number was [f 2 4 1].[n][f 1 1][e]

--- a/OtherMods/DungeonOptions/GohoM.flow
+++ b/OtherMods/DungeonOptions/GohoM.flow
@@ -1,4 +1,5 @@
 import("GohoM.msg");
+import("DungeonError.msg");
 
 void use_gohom()
 {
@@ -132,7 +133,7 @@ void use_gohom()
     }
 
     TRAESTO_VISUAL();
-    
+
     if ( var17 > 5 && var17 < 20 )
     {
         CALL_DUNGEON( 5, 1 );
@@ -171,6 +172,10 @@ void use_gohom()
     }
     else 
     {
+        SET_MSG_VAR(1, var17, 0);
+        OPEN_MSG_WIN();
+        MSG(GOHOM_ERROR);
+        CLOSE_MSG_WIN();
         CALL_DUNGEON( 5, 1 ); // Yukiko's castle entrance in case we can't find the dungeon
     }
 }

--- a/OtherMods/DungeonOptions/GohoM.flow
+++ b/OtherMods/DungeonOptions/GohoM.flow
@@ -169,6 +169,9 @@ void use_gohom()
     {
         CALL_DUNGEON( 160, 1 );
     }
-
+    else 
+    {
+        CALL_DUNGEON( 5, 1 ); // Yukiko's castle entrance in case we can't find the dungeon
+    }
 }
 

--- a/OtherMods/QuickTravelPlus.flow
+++ b/OtherMods/QuickTravelPlus.flow
@@ -152,7 +152,7 @@ void StreetOrder(bool calendar, bool friend, bool save)
 		case 0:
 			SEL_CHK_PAD(14, 5);
 			int shopping = ADV_SEL( Street_Text, ShoppingDistrictDay, shoppingMask );
-			if (shopping < 4) 
+			if (shopping < 2) 
 			{
 				FADE( 2, 5 );
 				FADE_SYNC();
@@ -172,12 +172,10 @@ void StreetOrder(bool calendar, bool friend, bool save)
 						CALL_FIELD( 8, 2, 0, 0 );
 					break;
 				case 2:
-					DAIDARA_SHOP();
-					CALL_FIELD(8, 2, 2, 0 );
+					equip_shop();
 					break;
 				case 3:
-					SHIROKU_SHOP();
-					CALL_FIELD(8, 2, 3, 0);
+					item_shop();
 					break;
 				case 4:
 					call_velvet_room();
@@ -431,7 +429,7 @@ void NightOrder(bool calendar, bool friend, bool save)
 		case 0:
 			SEL_CHK_PAD(14, 4);
 			int shopping = ADV_SEL( Street_Text, ShoppingDistrict, streetMask );
-			if (shopping < 3) 
+			if (shopping < 2) 
 			{
 				FADE( 2, 5 );
 				FADE_SYNC();
@@ -451,44 +449,7 @@ void NightOrder(bool calendar, bool friend, bool save)
 						CALL_FIELD( 8, 2, 0, 0 );
 					break;
 				case 2:
-					BIT_ON( 0 + 0x0400 + 844 );
-					BIT_ON( 0 + 0x0400 + 845 );
-					BIT_ON( 0 + 0x0400 + 846 );
-					BIT_ON( 0 + 0x0400 + 847 );
-					
-					if ( GET_DAY_OF_WEEK() == 1 )
-					{
-						BIT_OFF( 0 + 0x0400 + 844 );
-					}
-					else if ( GET_DAY_OF_WEEK() == 2 )
-					{
-						BIT_OFF( 0 + 0x0400 + 847 );
-					}
-					else if ( GET_DAY_OF_WEEK() == 3 )
-					{
-						BIT_OFF( 0 + 0x0400 + 846 );
-					}
-					else if ( GET_DAY_OF_WEEK() == 4 )
-					{
-						BIT_OFF( 0 + 0x0400 + 845 );
-					}
-					else 
-					{
-						BIT_OFF( 0 + 0x0400 + 844 );
-						BIT_OFF( 0 + 0x0400 + 845 );
-						BIT_OFF( 0 + 0x0400 + 846 );
-						BIT_OFF( 0 + 0x0400 + 847 );
-					}
-					BIT_ON( 0 + 0x0400 + 1067 );
-					SHIROKU_PUB();
-					if ( BIT_CHK( 0 + 0x0400 + 1057 ) == 1 )
-					{
-						commu_yoru();
-					}
-					else 
-					{
-						CALL_FIELD( 8, 2, 3, 0 );
-					}
+					item_shop();
 					break;
 				case 3:
 					call_velvet_room();
@@ -793,6 +754,209 @@ void call_velvet_room()
     else 
     {
         CALL_FIELD( 8, 2, 4, 0 );
+    }
+
+}
+
+void equip_shop()
+{
+    
+    if ( CHECK_TIME_SPAN( 4, 11, 4, 12 ) == 1 )
+    {
+        OPEN_MSG_WIN();
+        MSG( EQUIP_SHOP_STOP );
+        CLOSE_MSG_WIN();
+    }
+    else if ( ( ( GET_TIME_OF_DAY() == 5 ) && ( GET_WEATHER() != 1 ) ) && ( GET_WEATHER() != 7 ) )
+    {
+        OPEN_MSG_WIN();
+        MSG( EQUIP_SHOP_CLOSED );
+        CLOSE_MSG_WIN();
+    }
+    else if ( ( BIT_CHK( 1538 ) == 1 ) && ( BIT_CHK( 131 ) == 0 ) )
+    {
+        commu_gojitu();
+        return;
+    }
+    else 
+    {
+        FADE( 1, 10 );
+        FADE_SYNC();
+        DAIDARA_SHOP();
+        CALL_FIELD( 8, 2, 2, 0 );
+    }
+
+}
+
+
+// Procedure Index: 43
+void item_shop()
+{
+    
+    if ( CHECK_TIME_SPAN( 4, 11, 4, 12 ) == 1 )
+    {
+        OPEN_MSG_WIN();
+        MSG( MSG_ITEMSHOP_0411 );
+        CLOSE_MSG_WIN();
+    }
+    else if ( GET_TIME_OF_DAY() == 5 )
+    {
+        BIT_ON( 1868 );
+        BIT_ON( 1869 );
+        BIT_ON( 1870 );
+        BIT_ON( 1871 );
+        
+        if ( GET_DAY_OF_WEEK() == 1 )
+        {
+            BIT_OFF( 1868 );
+        }
+        else if ( GET_DAY_OF_WEEK() == 2 )
+        {
+            BIT_OFF( 1871 );
+        }
+        else if ( GET_DAY_OF_WEEK() == 3 )
+        {
+            BIT_OFF( 1870 );
+        }
+        else if ( GET_DAY_OF_WEEK() == 4 )
+        {
+            BIT_OFF( 1869 );
+        }
+        else 
+        {
+            BIT_OFF( 1868 );
+            BIT_OFF( 1869 );
+            BIT_OFF( 1870 );
+            BIT_OFF( 1871 );
+        }
+
+        FADE( 1, 10 );
+        FADE_SYNC();
+        BIT_ON( 2091 );
+        SHIROKU_PUB();
+        
+        if ( BIT_CHK( 2081 ) == 1 )
+        {
+            commu_yoru();
+        }
+        else 
+        {
+            CALL_FIELD( 8, 2, 3, 0 );
+        }
+
+    }
+    else if ( ( BIT_CHK( 1538 ) == 1 ) && ( BIT_CHK( 131 ) == 0 ) )
+    {
+        commu_gojitu();
+        return;
+    }
+    else 
+    {
+        FADE( 1, 10 );
+        FADE_SYNC();
+        SHIROKU_SHOP();
+        CALL_FIELD( 8, 2, 3, 0 );
+    }
+
+}
+
+
+void commu_gojitu()
+{
+    int var119;
+    
+    if ( BIT_CHK( 3405 ) == 1 )
+    {
+        OPEN_MSG_WIN();
+        
+        if ( BIT_CHK( 1591 ) == 1 )
+        {
+            MSG( MSG_0320_NOMORE_NEED3 );
+            CLOSE_MSG_WIN();
+            return;
+        }
+        else if ( BIT_CHK( 1539 ) == 1 )
+        {
+            
+            if ( BIT_CHK( 2304 ) == 1 )
+            {
+                MSG( MSG_0320_GO_HOME_COMU_AL_2 );
+            }
+            else 
+            {
+                MSG( MSG_0320_GO_HOME_COMU_NO_2 );
+                CLOSE_MSG_WIN();
+                return;
+            }
+
+        }
+        else 
+        {
+            MSG( MSG_0320_RETURN_HOME2 );
+        }
+
+        SEL_CHK_PAD( 14, 1 );
+        var119 = SEL( YESNO_SEL );
+        CLOSE_MSG_WIN();
+        
+        if ( var119 == 0 )
+        {
+            
+            if ( BIT_CHK( 3076 ) == 0 )
+            {
+                BIT_ON( 3076 );
+            }
+
+            
+            if ( DATE_CHK( 3, 20 ) )
+            {
+                BIT_ON( 46 );
+            }
+
+            FADE( 1, 10 );
+            FADE_SYNC();
+            TV_STUDIO();
+            return;
+        }
+        else 
+        {
+            return;
+        }
+
+    }
+    else 
+    {
+        OPEN_MSG_WIN();
+        
+        if ( BIT_CHK( 1591 ) == 1 )
+        {
+            MSG( MSG_0320_NOMORE_NEED3 );
+            CLOSE_MSG_WIN();
+            return;
+        }
+        else if ( BIT_CHK( 1539 ) == 1 )
+        {
+            
+            if ( BIT_CHK( 2304 ) == 1 )
+            {
+                MSG( MSG_0320_GO_HOME_COMU_AL_3 );
+            }
+            else 
+            {
+                MSG( MSG_0320_GO_HOME_COMU_NO_2 );
+                CLOSE_MSG_WIN();
+                gojitudan_guide();
+                return;
+            }
+
+        }
+        else 
+        {
+            MSG( MSG_0320_RETURN_HOME2 );
+        }
+
+        CLOSE_MSG_WIN();
+        return;
     }
 
 }

--- a/OtherMods/QuickTravelPlus.msg
+++ b/OtherMods/QuickTravelPlus.msg
@@ -114,3 +114,41 @@
 [f 0 5 -258][f 2 1]> You should have no reason to come[n]here anymore...[n][f 1 1][e]
 [f 0 5 -258][f 2 1]> You now have said goodbye to everyone[n]who is close to you.[n][f 1 1][e]
 [f 0 5 -258][f 2 1]> It's time for you to go back home to[n]prepare for tomorrow...[n][f 1 1][e]
+
+[msg EQUIP_SHOP_STOP]
+[s]> A fierce-looking man is single-mindedly[n]pounding on something in the back of the[n]store...[n][w][e]
+[s]> You decide not to enter...[n][w][e]
+
+[msg EQUIP_SHOP_CLOSED]
+[s]> The store has closed for today...[n][w][e]
+
+[msg MSG_ITEMSHOP_0411]
+[s]> A variety of products lines the[n]shelves...[n][w][e]
+[s]> A friendly-looking old lady sits behind[n]the counter...[n][w][e]
+
+[msg MSG_0320_NOMORE_NEED2]
+[s]> You should have no reason to come[n]here anymore...[n][w][e]
+
+[msg MSG_0320_GO_HOME_COMU_NO_2]
+[s]> You should have no reason to come[n]here anymore...[n][w][e]
+[s]> You have yet to speak with some of[n]the people who are close to you.[n][w][e]
+
+[msg MSG_0320_GO_HOME_COMU_AL_2]
+[s]> You should have no reason to come[n]here anymore...[n][w][e]
+[s]> You now have said goodbye to everyone[n]who is close to you.[n][w][e]
+[s]> It's time for you to go back home to[n]prepare for tomorrow...[n][w][e]
+
+[msg MSG_0320_RETURN_HOME2]
+[s]> You should have no reason to come[n]here anymore...[n][w][e]
+[s]> It's time for you to go back home to[n]prepare for tomorrow...[n][w][e]
+
+[msg MSG_0320_NOMORE_NEED3]
+[s]> There's no reason for you to be here...[n][w][e]
+
+[msg MSG_0320_GO_HOME_COMU_AL_3]
+[s]> You should have no reason to come[n]here anymore...[n][w][e]
+[s]> You now have said goodbye to everyone[n]who is close to you.[n][w][e]
+[s]> Is there something that you still[n]have to do here...?[n][w][e]
+
+[msg MSG_0417_VELVET_DONOTENT]
+[s]> You have no need to enter here...[n][w][e]

--- a/field/script/lmap.flow
+++ b/field/script/lmap.flow
@@ -245,6 +245,7 @@ void call_velvet_room()
                 {
                     MSG( MSG_0320_GO_HOME_COMU_NO2 );
                     CLOSE_MSG_WIN();
+                    TOWN_MAP(0);
                     return;
                 }
 
@@ -268,6 +269,7 @@ void call_velvet_room()
             }
             else 
             {
+                TOWN_MAP(0);
                 return;
             }
 
@@ -296,6 +298,7 @@ void call_velvet_room()
             }
 
             CLOSE_MSG_WIN();
+            TOWN_MAP(0);
 			return;
         }
 
@@ -305,6 +308,7 @@ void call_velvet_room()
         OPEN_MSG_WIN();
         MSG( MSG_0320_DOUJIMA_SEARCH );
         CLOSE_MSG_WIN();
+        TOWN_MAP(0);
 		return;
     }
     else if ( var6 == 3 && var7 == 20 && BIT_CHK( 0 + 1019 ) && BIT_CHK( 0 + 0x0400 + 566 ) == 0 )
@@ -339,6 +343,7 @@ void call_velvet_room()
         OPEN_MSG_WIN();
         MSG( MSG_0320_NOMORE_NEED3 );
         CLOSE_MSG_WIN();
+        TOWN_MAP(0);
 		return;
     }
     else if ( var6 == 4 && var7 == 17 )
@@ -346,6 +351,7 @@ void call_velvet_room()
         OPEN_MSG_WIN();
         MSG( MSG_0417_VELVET_DONOTENT );
         CLOSE_MSG_WIN();
+        TOWN_MAP(0);
 		return;
     }
     else if ( GET_TIME_OF_DAY() == 5 )

--- a/field/script/lmap.flow
+++ b/field/script/lmap.flow
@@ -163,12 +163,10 @@ void StreetOrder()
 			CALL_FIELD( 8, 9, 0, 0 );
 			break;
 		case 3:
-			DAIDARA_SHOP();
-			CALL_FIELD(8, 2, 2, 0 );
+			equip_shop();
 			break;
 		case 4:
-			SHIROKU_SHOP();
-			CALL_FIELD(8, 2, 3, 0);
+            item_shop();
 			break;
 		case 5:
 			call_velvet_room();
@@ -578,4 +576,759 @@ void eve_0320_vs_marguerite()
     BIT_ON( 0 + 0x0400 + 0x0800 + 785 );
     BIT_ON( 0 + 0x0400 + 0x0800 + 788 );
     SET_CNT( 28, 0 );
+}
+
+void equip_shop()
+{
+    
+    if ( CHECK_TIME_SPAN( 4, 11, 4, 12 ) == 1 )
+    {
+        OPEN_MSG_WIN();
+        MSG( EQUIP_SHOP_STOP );
+        CLOSE_MSG_WIN();
+        TOWN_MAP(0);
+    }
+    else if ( ( ( GET_TIME_OF_DAY() == 5 ) && ( GET_WEATHER() != 1 ) ) && ( GET_WEATHER() != 7 ) )
+    {
+        OPEN_MSG_WIN();
+        MSG( EQUIP_SHOP_CLOSED );
+        CLOSE_MSG_WIN();
+        TOWN_MAP(0);
+    }
+    else if ( ( BIT_CHK( 1538 ) == 1 ) && ( BIT_CHK( 131 ) == 0 ) )
+    {
+        commu_gojitu();
+        TOWN_MAP(0);
+        return;
+    }
+    else 
+    {
+        FADE( 1, 10 );
+        FADE_SYNC();
+        DAIDARA_SHOP();
+        CALL_FIELD( 8, 2, 2, 0 );
+    }
+
+}
+
+
+// Procedure Index: 43
+void item_shop()
+{
+    
+    if ( CHECK_TIME_SPAN( 4, 11, 4, 12 ) == 1 )
+    {
+        OPEN_MSG_WIN();
+        MSG( MSG_ITEMSHOP_0411 );
+        CLOSE_MSG_WIN();
+        TOWN_MAP(0);
+    }
+    else if ( GET_TIME_OF_DAY() == 5 )
+    {
+        BIT_ON( 1868 );
+        BIT_ON( 1869 );
+        BIT_ON( 1870 );
+        BIT_ON( 1871 );
+        
+        if ( GET_DAY_OF_WEEK() == 1 )
+        {
+            BIT_OFF( 1868 );
+        }
+        else if ( GET_DAY_OF_WEEK() == 2 )
+        {
+            BIT_OFF( 1871 );
+        }
+        else if ( GET_DAY_OF_WEEK() == 3 )
+        {
+            BIT_OFF( 1870 );
+        }
+        else if ( GET_DAY_OF_WEEK() == 4 )
+        {
+            BIT_OFF( 1869 );
+        }
+        else 
+        {
+            BIT_OFF( 1868 );
+            BIT_OFF( 1869 );
+            BIT_OFF( 1870 );
+            BIT_OFF( 1871 );
+        }
+
+        FADE( 1, 10 );
+        FADE_SYNC();
+        BIT_ON( 2091 );
+        SHIROKU_PUB();
+        
+        if ( BIT_CHK( 2081 ) == 1 )
+        {
+            commu_yoru();
+        }
+        else 
+        {
+            CALL_FIELD( 8, 2, 3, 0 );
+        }
+    }
+    else if ( ( BIT_CHK( 1538 ) == 1 ) && ( BIT_CHK( 131 ) == 0 ) )
+    {
+        commu_gojitu();
+        TOWN_MAP(0);
+        return;
+    }
+    else 
+    {
+        FADE( 1, 10 );
+        FADE_SYNC();
+        SHIROKU_SHOP();
+        CALL_FIELD( 8, 2, 3, 0 );
+    }
+
+}
+
+
+void commu_gojitu()
+{
+    int var119;
+    
+    if ( BIT_CHK( 3405 ) == 1 )
+    {
+        OPEN_MSG_WIN();
+        
+        if ( BIT_CHK( 1591 ) == 1 )
+        {
+            MSG( MSG_0320_NOMORE_NEED3 );
+            CLOSE_MSG_WIN();
+            return;
+        }
+        else if ( BIT_CHK( 1539 ) == 1 )
+        {
+            
+            if ( BIT_CHK( 2304 ) == 1 )
+            {
+                MSG( MSG_0320_GO_HOME_COMU_AL_2 );
+            }
+            else 
+            {
+                MSG( MSG_0320_GO_HOME_COMU_NO_2 );
+                CLOSE_MSG_WIN();
+                return;
+            }
+
+        }
+        else 
+        {
+            MSG( MSG_0320_RETURN_HOME2 );
+        }
+
+        SEL_CHK_PAD( 14, 1 );
+        var119 = SEL( YESNO_SEL );
+        CLOSE_MSG_WIN();
+        
+        if ( var119 == 0 )
+        {
+            
+            if ( BIT_CHK( 3076 ) == 0 )
+            {
+                BIT_ON( 3076 );
+            }
+
+            
+            if ( DATE_CHK( 3, 20 ) )
+            {
+                BIT_ON( 46 );
+            }
+
+            FADE( 1, 10 );
+            FADE_SYNC();
+            TV_STUDIO();
+            return;
+        }
+        else 
+        {
+            return;
+        }
+
+    }
+    else 
+    {
+        OPEN_MSG_WIN();
+        
+        if ( BIT_CHK( 1591 ) == 1 )
+        {
+            MSG( MSG_0320_NOMORE_NEED3 );
+            CLOSE_MSG_WIN();
+            return;
+        }
+        else if ( BIT_CHK( 1539 ) == 1 )
+        {
+            
+            if ( BIT_CHK( 2304 ) == 1 )
+            {
+                MSG( MSG_0320_GO_HOME_COMU_AL_3 );
+            }
+            else 
+            {
+                MSG( MSG_0320_GO_HOME_COMU_NO_2 );
+                CLOSE_MSG_WIN();
+                gojitudan_guide();
+                return;
+            }
+
+        }
+        else 
+        {
+            MSG( MSG_0320_RETURN_HOME2 );
+        }
+
+        CLOSE_MSG_WIN();
+        return;
+    }
+
+}
+
+void commu_yoru()
+{
+    int var134;
+    int var135;
+    int var137;
+    var134 = GET_MONTH();
+    var135 = GET_DAY_OF_MONTH();
+    var137 = GET_TIME_OF_DAY();
+    
+    if ( ( var134 == 4 ) && ( var135 == 11 ) )
+    {
+        eve_0411_midnight();
+        return;
+    }
+    else if ( ( var134 == 4 ) && ( var135 == 13 ) )
+    {
+        eve_0413_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 4 ) && ( var135 == 15 ) )
+    {
+        eve_0415_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 4 ) && ( var135 == 0x10 ) )
+    {
+        eve_0416_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 4 ) && ( var135 == 29 ) )
+    {
+        eve_0429_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 5 ) && ( var135 == 14 ) )
+    {
+        eve_0514_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 5 ) && ( var135 == 15 ) )
+    {
+        eve_0515_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 5 ) && ( var135 == 17 ) )
+    {
+        eve_0517_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 6 ) && ( var135 == 4 ) )
+    {
+        eve_0604_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 6 ) && ( var135 == 21 ) )
+    {
+        eve_0621_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 6 ) && ( var135 == 23 ) )
+    {
+        eve_0623_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 7 ) && ( var135 == 9 ) )
+    {
+        eve_0709_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 7 ) && ( var135 == 10 ) )
+    {
+        eve_0710_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 7 ) && ( var135 == 26 ) )
+    {
+        eve_0726_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 8 ) && ( var135 == 12 ) )
+    {
+        eve_0812_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 9 ) && ( var135 == 14 ) )
+    {
+        eve_0914_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 9 ) && ( var135 == 15 ) )
+    {
+        eve_0915_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 10 ) && ( var135 == 5 ) )
+    {
+        eve_1005_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 11 ) && ( var135 == 20 ) )
+    {
+        eve_1120_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 12 ) && ( var135 == 3 ) )
+    {
+        eve_1203_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 12 ) && ( var135 == 5 ) )
+    {
+        eve_1205_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 12 ) && ( var135 == 7 ) )
+    {
+        eve_1207_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 12 ) && ( var135 == 26 ) )
+    {
+        eve_1226_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 1 ) && ( var135 == 3 ) )
+    {
+        eve_0103_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 1 ) && ( var135 == 17 ) )
+    {
+        eve_0117_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 1 ) && ( var135 == 24 ) )
+    {
+        eve_0124_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else if ( ( var134 == 2 ) && ( var135 == 2 ) )
+    {
+        eve_0202_midnight();
+        TV_STUDIO();
+        return;
+    }
+    else 
+    {
+        TV_STUDIO();
+        return;
+    }
+
+}
+
+// Procedure Index: 80
+void eve_0413_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 121, 1, 0 );
+    PLAY_CUTSCENE( 3 );
+    FUNCTION_0065();
+    CALL_EVENT( 121, 2, 0 );
+}
+
+
+// Procedure Index: 81
+void eve_0415_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 153, 1, 0 );
+    SHOW_DATE( 0 );
+    CALL_EVENT( 154, 1, 0 );
+    SHOW_DATE( 1 );
+    SET_ITEM( ( 0x0400 + 1 ), 1 );
+}
+
+
+// Procedure Index: 82
+void eve_0416_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 162, 2, 0 );
+    PLAY_CUTSCENE( 7 );
+    FUNCTION_0065();
+    CALL_EVENT( 162, 1, 0 );
+}
+
+
+// Procedure Index: 83
+void eve_0417_afterschool()
+{
+    CALL_EVENT( 169, 1, 0 );
+    FCL_FUNCTION_0001();
+    FCL_FUNCTION_0002();
+    FCL_FUNCTION_0003();
+    CALL_EVENT( 170, 1, 0 );
+    CALL_EVENT( 171, 1, 0 );
+    CALL_DUNGEON( 5, 0 );
+}
+
+
+// Procedure Index: 84
+void eve_0514_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 197, 1, 0 );
+}
+
+
+// Procedure Index: 85
+void eve_0515_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 199, 1, 0 );
+    FUNCTION_006B( -1 );
+}
+
+
+// Procedure Index: 86
+void eve_0517_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 207, 1, 0 );
+    CALL_EVENT( 208, 1, 0 );
+    FUNCTION_006B( -1 );
+}
+
+
+// Procedure Index: 87
+void eve_0604_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 218, 1, 0 );
+    CALL_EVENT( 219, 1, 0 );
+}
+
+
+// Procedure Index: 88
+void eve_0621_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 235, 1, 0 );
+}
+
+
+// Procedure Index: 89
+void eve_0623_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 245, 1, 0 );
+}
+
+
+// Procedure Index: 90
+void eve_0709_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 0x0100, 1, 0 );
+    CALL_EVENT( 220, 1, 0 );
+}
+
+
+// Procedure Index: 91
+void eve_0710_midnight()
+{
+    SHOW_DATE( 0 );
+    CALL_EVENT( 267, 1, 0 );
+    SHOW_DATE( 1 );
+    BIT_ON( 4865 );
+    BIT_ON( 4866 );
+    BIT_ON( 4867 );
+}
+
+
+// Procedure Index: 92
+void eve_0726_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 273, 1, 0 );
+    INCREASE_SL( 24 );
+}
+
+
+// Procedure Index: 93
+void eve_0812_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 283, 1, 0 );
+    CALL_EVENT( 220, 1, 0 );
+}
+
+
+// Procedure Index: 94
+void eve_0914_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 300, 1, 0 );
+}
+
+
+// Procedure Index: 95
+void eve_0915_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 302, 1, 0 );
+}
+
+
+// Procedure Index: 96
+void eve_1005_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 310, 1, 0 );
+    CALL_EVENT( 311, 1, 0 );
+}
+
+
+// Procedure Index: 97
+void eve_1120_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 360, 1, 0 );
+    CALL_EVENT( 220, 1, 0 );
+}
+
+
+// Procedure Index: 98
+void eve_1205_midnight()
+{
+    INCREASE_SL( 24 );
+    SHOW_DATE( 0 );
+    CALL_EVENT( 386, 2, 0 );
+    SHOW_DATE( 1 );
+    BIT_ON( 694 );
+}
+
+
+// Procedure Index: 99
+void eve_1207_midnight()
+{
+    
+    if ( GET_SL_LEVEL( 31 ) == 8 )
+    {
+        PLAY_SOUNDEFFECT( 173 );
+        CALL_EVENT( 730, 571, 0 );
+        
+        if ( BIT_CHK( 5656 ) == 1 )
+        {
+            CALL_EVENT( 730, 572, 0 );
+            CALL_EVENT( 730, 573, 0 );
+            CALL_EVENT( 730, 574, 0 );
+        }
+
+    }
+
+}
+
+
+// Procedure Index: 100
+void eve_0320_backhome()
+{
+    CALL_EVENT( 428, 1, 0 );
+    PLAY_CUTSCENE( 17 );
+    FUNCTION_0065();
+    SOFT_RESET();
+}
+
+// Procedure Index: 102
+void eve_1203_midnight()
+{
+    SHOW_DATE( 0 );
+    CALL_EVENT( 386, 1, 0 );
+    SHOW_DATE( 1 );
+}
+
+
+// Procedure Index: 103
+void eve_0320_foodcourt()
+{
+    
+    if ( BIT_CHK( 2067 ) == 1 )
+    {
+        INCREASE_SL( 0x20 );
+    }
+
+    CALL_EVENT( 429, 1, 0 );
+    BIT_ON( 1591 );
+    BIT_OFF( 1018 );
+    FUNCTION_006B( 2 );
+}
+
+// Procedure Index: 105
+void eve_0411_midnight()
+{
+    SHOW_DATE( 0 );
+    CALL_EVENT( 465, 2, 0 );
+    SHOW_DATE( 1 );
+    CALL_DUNGEON( 159, 0 );
+}
+
+
+// Procedure Index: 106
+void eve_0429_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 183, 1, 0 );
+    CALL_EVENT( 182, 2, 0 );
+}
+
+
+// Procedure Index: 107
+void eve_0213_midnight()
+{
+    
+    if ( BIT_CHK( 5665 ) == 0 )
+    {
+        BIT_ON( 5690 );
+    }
+
+}
+
+
+// Procedure Index: 108
+void eve_1226_midnight()
+{
+    PLAY_SOUNDEFFECT( 173 );
+    CALL_EVENT( 490, 501, 0 );
+    BIT_ON( 5715 );
+    FUNCTION_006B( -1 );
+    NEXT_DATE( 12, 31, 0 );
+}
+
+
+// Procedure Index: 109
+void eve_1227_midnight()
+{
+    
+    if ( BIT_CHK( 5682 ) == 0 )
+    {
+        PLAY_SOUNDEFFECT( 173 );
+        SHOW_DATE( 0 );
+        CALL_EVENT( 492, 500, 0 );
+        SHOW_DATE( 1 );
+    }
+
+    BIT_ON( 1682 );
+}
+
+
+// Procedure Index: 110
+void eve_0102_midnight()
+{
+    
+    if ( BIT_CHK( 3251 ) == 0 )
+    {
+        BIT_ON( 5690 );
+        BIT_ON( 5682 );
+        CALL_EVENT( 426, 2, 0 );
+        NEXT_DATE( 2, 11, 0 );
+    }
+
+}
+
+
+// Procedure Index: 111
+void eve_0103_midnight()
+{
+    CALL_EVENT( 492, 0x0200, 0 );
+    SHOW_DATE( 0 );
+    
+    if ( BIT_CHK( 3251 ) == 1 )
+    {
+        CALL_EVENT( 492, 503, 0 );
+    }
+    else 
+    {
+        CALL_EVENT( 492, 509, 0 );
+    }
+
+    SHOW_DATE( 1 );
+}
+
+
+// Procedure Index: 112
+void eve_0117_midnight()
+{
+    
+    if ( BIT_CHK( 3251 ) == 1 )
+    {
+        SHOW_DATE( 0 );
+        CALL_EVENT( 492, 504, 0 );
+        SHOW_DATE( 1 );
+    }
+
+}
+
+
+// Procedure Index: 113
+void eve_0124_midnight()
+{
+    
+    if ( BIT_CHK( 3251 ) == 1 )
+    {
+        SHOW_DATE( 0 );
+        CALL_EVENT( 492, 505, 0 );
+        SHOW_DATE( 1 );
+    }
+
+}
+
+
+// Procedure Index: 114
+void eve_0202_midnight()
+{
+    
+    if ( BIT_CHK( 3251 ) == 1 )
+    {
+        SHOW_DATE( 0 );
+        CALL_EVENT( 492, 506, 0 );
+        SHOW_DATE( 1 );
+    }
+
 }

--- a/field/script/lmap.msg
+++ b/field/script/lmap.msg
@@ -86,7 +86,6 @@
 [f 0 5 -258][f 2 1]> You should have no reason to come[n]here anymore...[n][f 1 1][e]
 [f 0 5 -258][f 2 1]> You have yet to speak with some of[n]the people who are close to you.[n][f 1 1][e]
 
-
 [msg MSG_0320_RETURN_HOME2]
 [f 0 5 -258][f 2 1]> You should have no reason to come[n]here anymore...[n][f 1 1][e]
 [f 0 5 -258][f 2 1]> It's time for you to go back home to[n]prepare for tomorrow...[n][f 1 1][e]
@@ -177,3 +176,49 @@
 [msg MSG_GOJITUDAN_GUIDE_AI]
 [f 0 5 -258][f 2 1]> Come to think of it, you have yet[n]to say goodbye to Ai...[n][f 1 1][e]
 [f 0 5 -258][f 2 1]> Ai was always standing around at the[n][f 0 1 2]first floor hallway of the school's[n]Classroom Building[f 0 1 0]...[n][f 1 1][e]
+
+[msg EQUIP_SHOP_STOP]
+[f 2 1]> A fierce-looking man is single-mindedly[n]pounding on something in the back of the[n]store...[n][f 1 1][e]
+[f 2 1]> You decide not to enter...[n][f 1 1][e]
+
+[msg EQUIP_SHOP_CLOSED]
+[f 2 1]> The store has closed for today...[n][f 1 1][e]
+
+[msg MSG_0320_GO_HOME_COMU_AL_2]
+[f 0 5 65278][f 2 1]> You should have no reason to come[n]here anymore...[n][f 1 1][e]
+[f 0 5 65278][f 2 1]> You now have said goodbye to everyone[n]who is close to you.[n][f 1 1][e]
+[f 0 5 65278][f 2 1]> Is there something that you still[n]have to do here...?[n][f 1 1][e]
+
+[msg MSG_ITEMSHOP_0411]
+[f 2 1]> A variety of products lines the[n]shelves...[n][f 1 1][e]
+[f 2 1]> A friendly-looking old lady sits behind[n]the counter...[n][f 1 1][e]
+
+[msg MSG_0320_NOMORE_NEED2]
+[f 2 1]> You should have no reason to come[n]here anymore...[n][f 1 1][e]
+
+[msg MSG_0320_GO_HOME_COMU_NO_3]
+[f 2 1]> You should have no reason to come[n]here anymore...[n][f 1 1][e]
+[f 2 1]> You have yet to speak with some of[n]the people who are close to you.[n][f 1 1][e]
+
+[msg MSG_0320_GO_HOME_COMU_AL_4]
+[f 2 1]> You should have no reason to come[n]here anymore...[n][f 1 1][e]
+[f 2 1]> You now have said goodbye to everyone[n]who is close to you.[n][f 1 1][e]
+[f 2 1]> It's time for you to go back home to[n]prepare for tomorrow...[n][f 1 1][e]
+
+[msg MSG_0320_GO_HOME_COMU_AL_5]
+[f 2 1]> You should have no reason to come[n]here anymore...[n][f 1 1][e]
+[f 2 1]> You now have said goodbye to everyone[n]who is close to you.[n][f 1 1][e]
+[f 2 1]> Is there something that you still[n]have to do here...?[n][f 1 1][e]
+
+[sel YESNO_SEL top]
+[f 0 5 65278][f 2 1]Yes[e]
+[f 0 5 65278][f 2 1]No[e]
+
+[msg MSG_0320_GO_HOME_COMU_NO_2]
+[f 0 5 65278][f 2 1]> You should have no reason to come[n]here anymore...[n][f 1 1][e]
+[f 0 5 65278][f 2 1]> You have yet to speak with some of[n]the people who are close to you.[n][f 1 1][e]
+
+[msg MSG_0320_GO_HOME_COMU_AL_3]
+[f 0 5 65278][f 2 1]> You should have no reason to come[n]here anymore...[n][f 1 1][e]
+[f 0 5 65278][f 2 1]> You now have said goodbye to everyone[n]who is close to you.[n][f 1 1][e]
+[f 0 5 65278][f 2 1]> It's time for you to go back home to[n]prepare for tomorrow...[n][f 1 1][e]


### PR DESCRIPTION
- Fixed a bug where you would become softlocked when trying to enter the velvet room from the town map when it was unavailable.
- Fixed being able to enter the Shiroku Shop and Daidara through quick travel or the town map when they should be unavailable
- Made it so using a goho-m from the dungeon menu will fall back to traveling to Yukiko's dungeon entrance if it cannot determine which dungeon you're in to prevent a softlock. If this does happen to you please report it, the reason this happens is currently unknown
